### PR TITLE
Add IdleRPG homepage layout with skill tabs

### DIFF
--- a/assets/css/idle.css
+++ b/assets/css/idle.css
@@ -1,0 +1,329 @@
+:root {
+    --bg-dark: #1c1f2b;
+    --bg-panel: #2b3042;
+    --bg-highlight: #3c445c;
+    --accent-gold: #d4af37;
+    --accent-emerald: #6bbf59;
+    --accent-sky: #73c2fb;
+    --text-primary: #f5f1e6;
+    --text-muted: #c7c3b8;
+    --border-color: rgba(244, 229, 186, 0.2);
+    --shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+    --font-display: 'Uncial Antiqua', cursive;
+    --font-body: 'Nunito', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, #31405c 0%, #151724 65%, #0a0b12 100%);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    display: flex;
+    justify-content: center;
+    align-items: stretch;
+    padding: 2rem;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: url('https://www.transparenttextures.com/patterns/stardust.png');
+    opacity: 0.25;
+    z-index: -1;
+}
+
+.idle-app {
+    display: grid;
+    grid-template-columns: 280px minmax(0, 1fr);
+    width: min(1200px, 100%);
+    background: rgba(12, 16, 30, 0.92);
+    border: 1px solid var(--border-color);
+    border-radius: 18px;
+    box-shadow: var(--shadow);
+    overflow: hidden;
+}
+
+.sidebar {
+    background: linear-gradient(180deg, rgba(28, 31, 43, 0.95) 0%, rgba(18, 20, 30, 0.95) 100%);
+    padding: 2rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    border-right: 1px solid var(--border-color);
+}
+
+.brand h1 {
+    font-family: var(--font-display);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 2rem;
+    margin: 0;
+    color: var(--accent-gold);
+    text-shadow: 0 0 16px rgba(212, 175, 55, 0.45);
+}
+
+.brand .tagline {
+    margin: 0.5rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.skill-tabs ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.tab-button {
+    width: 100%;
+    background: rgba(65, 76, 109, 0.45);
+    border: 1px solid transparent;
+    color: var(--text-primary);
+    font-weight: 600;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    text-align: left;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tab-button:hover,
+.tab-button:focus {
+    outline: none;
+    transform: translateX(4px);
+    border-color: rgba(115, 194, 251, 0.7);
+    box-shadow: 0 0 12px rgba(115, 194, 251, 0.35);
+}
+
+.tab-button.active {
+    background: linear-gradient(90deg, rgba(212, 175, 55, 0.85), rgba(107, 191, 89, 0.85));
+    border-color: rgba(212, 175, 55, 0.65);
+    color: #12141e;
+    text-shadow: none;
+}
+
+.sidebar-footer {
+    margin-top: auto;
+}
+
+.tamir-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--text-primary);
+    background: linear-gradient(90deg, rgba(115, 194, 251, 0.4), rgba(212, 175, 55, 0.4));
+    border: 1px solid rgba(115, 194, 251, 0.4);
+    transition: transform 0.2s ease, background 0.3s ease, color 0.3s ease;
+}
+
+.tamir-link:hover,
+.tamir-link:focus {
+    transform: translateY(-2px);
+    background: linear-gradient(90deg, rgba(115, 194, 251, 0.75), rgba(212, 175, 55, 0.75));
+    color: #10131f;
+}
+
+.main-panel {
+    padding: 2rem 2.5rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.panel {
+    display: none;
+    background: rgba(37, 44, 66, 0.85);
+    border: 1px solid rgba(212, 175, 55, 0.2);
+    border-radius: 18px;
+    padding: 1.75rem;
+    box-shadow: inset 0 0 32px rgba(5, 8, 17, 0.55);
+}
+
+.panel header h2 {
+    font-family: var(--font-display);
+    font-size: 1.75rem;
+    margin: 0;
+    color: var(--accent-gold);
+}
+
+.panel header p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+}
+
+.panel.active {
+    display: block;
+}
+
+.panel.static-panel {
+    display: block;
+}
+
+.locations {
+    margin-top: 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+}
+
+.location-card {
+    background: rgba(21, 24, 38, 0.85);
+    border-radius: 16px;
+    padding: 1.25rem;
+    border: 1px solid rgba(115, 194, 251, 0.2);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
+}
+
+.location-card h3 {
+    margin: 0 0 0.75rem;
+    font-family: var(--font-display);
+    color: var(--accent-sky);
+}
+
+.location-card ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.location-card li strong {
+    color: var(--accent-emerald);
+}
+
+.bank-shop {
+    background: rgba(20, 24, 34, 0.85);
+}
+
+.inventory-grid,
+.shop-grid {
+    margin-top: 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+}
+
+.inventory-card,
+.shop-category {
+    background: rgba(32, 38, 54, 0.85);
+    border: 1px solid rgba(212, 175, 55, 0.18);
+    border-radius: 16px;
+    padding: 1.25rem;
+    box-shadow: inset 0 0 24px rgba(0, 0, 0, 0.35);
+}
+
+.inventory-card h3,
+.shop-category h3 {
+    margin: 0 0 0.75rem;
+    font-family: var(--font-display);
+    color: var(--accent-gold);
+}
+
+.inventory-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    color: var(--text-muted);
+}
+
+.upgrade-list {
+    padding-left: 1.25rem;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.upgrade-list li {
+    position: relative;
+    padding-left: 0.25rem;
+    color: var(--text-muted);
+}
+
+.upgrade-list li::marker {
+    color: var(--accent-sky);
+    font-weight: 700;
+}
+
+.upgrade-list li.unlocked {
+    color: var(--accent-emerald);
+}
+
+.upgrade-list li.locked {
+    opacity: 0.55;
+}
+
+.upgrade-list li.locked::after {
+    content: attr(data-requires) " required";
+    display: block;
+    font-size: 0.75rem;
+    color: rgba(115, 194, 251, 0.7);
+    margin-top: 0.15rem;
+}
+
+@media (max-width: 960px) {
+    body {
+        padding: 1rem;
+    }
+
+    .idle-app {
+        grid-template-columns: 240px 1fr;
+    }
+}
+
+@media (max-width: 760px) {
+    body {
+        padding: 0.5rem;
+    }
+
+    .idle-app {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .skill-tabs ul {
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .tab-button {
+        flex: 1 0 120px;
+    }
+
+    .main-panel {
+        padding: 1.5rem;
+    }
+}

--- a/assets/js/idle.js
+++ b/assets/js/idle.js
@@ -1,0 +1,58 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
+    const skillPanels = Array.from(document.querySelectorAll('.panel[data-panel="skill"]'));
+
+    if (!tabButtons.length || !skillPanels.length) {
+        return;
+    }
+
+    const activateTab = (targetId) => {
+        const targetPanel = skillPanels.find((panel) => panel.id === targetId);
+        if (!targetPanel) {
+            return;
+        }
+
+        tabButtons.forEach((button) => {
+            const isActive = button.dataset.tab === targetId;
+            button.classList.toggle('active', isActive);
+            button.setAttribute('aria-selected', String(isActive));
+        });
+
+        skillPanels.forEach((panel) => {
+            panel.classList.toggle('active', panel.id === targetId);
+        });
+
+        history.replaceState(null, '', `#${targetId}`);
+    };
+
+    tabButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            activateTab(button.dataset.tab);
+        });
+
+        button.addEventListener('keydown', (event) => {
+            if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+                return;
+            }
+            event.preventDefault();
+            const currentIndex = tabButtons.indexOf(button);
+            const offset = event.key === 'ArrowRight' ? 1 : -1;
+            const nextIndex = (currentIndex + offset + tabButtons.length) % tabButtons.length;
+            const nextButton = tabButtons[nextIndex];
+            nextButton.focus();
+            activateTab(nextButton.dataset.tab);
+        });
+    });
+
+    const initialHash = window.location.hash.replace('#', '');
+    if (initialHash && skillPanels.some((panel) => panel.id === initialHash)) {
+        activateTab(initialHash);
+    } else {
+        const activeButton = tabButtons.find((button) => button.classList.contains('active'));
+        if (activeButton) {
+            activateTab(activeButton.dataset.tab);
+        } else {
+            activateTab(skillPanels[0].id);
+        }
+    }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IdleRPG</title>
+    <link rel="stylesheet" href="assets/css/idle.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Uncial+Antiqua&family=Nunito:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="idle-app">
+        <aside class="sidebar">
+            <div class="brand">
+                <h1>IdleRPG</h1>
+                <p class="tagline">A cozy grind inspired by Gielinor & Pelican Town</p>
+            </div>
+            <nav class="skill-tabs" aria-label="Skill Navigation" role="tablist">
+                <ul>
+                    <li><button class="tab-button active" id="mining-tab" data-tab="mining" aria-controls="mining">Mining</button></li>
+                    <li><button class="tab-button" id="woodcutting-tab" data-tab="woodcutting" aria-controls="woodcutting">Woodcutting</button></li>
+                    <li><button class="tab-button" id="pickpocketing-tab" data-tab="pickpocketing" aria-controls="pickpocketing">Pickpocketing</button></li>
+                    <li><button class="tab-button" id="fishing-tab" data-tab="fishing" aria-controls="fishing">Fishing</button></li>
+                    <li><button class="tab-button" id="smithing-tab" data-tab="smithing" aria-controls="smithing">Smithing</button></li>
+                    <li><button class="tab-button" id="construction-tab" data-tab="construction" aria-controls="construction">Construction</button></li>
+                    <li><button class="tab-button" id="cooking-tab" data-tab="cooking" aria-controls="cooking">Cooking</button></li>
+                </ul>
+            </nav>
+            <div class="sidebar-footer">
+                <a class="tamir-link" href="/Tamir/">Visit the Obsidian Vault →</a>
+            </div>
+        </aside>
+        <main class="main-panel">
+            <section class="panel active" data-panel="skill" id="mining" aria-labelledby="mining-tab">
+                <header>
+                    <h2>Mining</h2>
+                    <p>Delve into the Stonefall Quarry and excavate rich veins of ore.</p>
+                </header>
+                <div class="locations">
+                    <article class="location-card">
+                        <h3>Stonefall Quarry</h3>
+                        <ul>
+                            <li><strong>Level 1:</strong> Shallow Pebble Patches — 10 XP, 3 Stone</li>
+                            <li><strong>Level 10:</strong> Copper Veins — 35 XP, 1 Copper Ore</li>
+                            <li><strong>Level 20:</strong> Iron Strata — 60 XP, 1 Iron Ore</li>
+                            <li><strong>Level 30:</strong> Silver Shard Crest — 120 XP, 1 Silver Ore</li>
+                        </ul>
+                    </article>
+                    <article class="location-card">
+                        <h3>Obsidian Breach</h3>
+                        <ul>
+                            <li><strong>Level 40:</strong> Basalt Clusters — 180 XP, 2 Basalt</li>
+                            <li><strong>Level 50:</strong> Obsidian Spurs — 260 XP, 1 Obsidian</li>
+                            <li><strong>Level 60:</strong> Dragonstone Geodes — 360 XP, 1 Dragonstone Shard</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="panel" data-panel="skill" id="woodcutting" aria-labelledby="woodcutting-tab">
+                <header>
+                    <h2>Woodcutting</h2>
+                    <p>Harvest the groves of Willowglade to gather timber and rare sap.</p>
+                </header>
+                <div class="locations">
+                    <article class="location-card">
+                        <h3>Willowglade Grove</h3>
+                        <ul>
+                            <li><strong>Level 1:</strong> Birch Saplings — 8 XP, 3 Birch Logs</li>
+                            <li><strong>Level 15:</strong> Maple Trees — 40 XP, 2 Maple Logs</li>
+                            <li><strong>Level 25:</strong> Willow Elders — 75 XP, 2 Willow Logs</li>
+                            <li><strong>Level 35:</strong> Elderwood Ents — 130 XP, 1 Elderwood Heart</li>
+                        </ul>
+                    </article>
+                    <article class="location-card">
+                        <h3>Mystwood Canopy</h3>
+                        <ul>
+                            <li><strong>Level 45:</strong> Redwood Sentinels — 210 XP, 3 Redwood Logs</li>
+                            <li><strong>Level 55:</strong> Stardrop Vines — 280 XP, 1 Stardrop Resin</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="panel" data-panel="skill" id="pickpocketing" aria-labelledby="pickpocketing-tab">
+                <header>
+                    <h2>Pickpocketing</h2>
+                    <p>Slip through the shadows of Emberreach to gather coin and curios.</p>
+                </header>
+                <div class="locations">
+                    <article class="location-card">
+                        <h3>Emberreach Bazaar</h3>
+                        <ul>
+                            <li><strong>Level 1:</strong> Distracted Tourists — 5 XP, 5 Coins</li>
+                            <li><strong>Level 15:</strong> Market Traders — 25 XP, 12 Coins</li>
+                            <li><strong>Level 30:</strong> Noble Envoys — 80 XP, 40 Coins</li>
+                        </ul>
+                    </article>
+                    <article class="location-card">
+                        <h3>Guildmaster's Vault</h3>
+                        <ul>
+                            <li><strong>Level 45:</strong> Rogue Apprentices — 120 XP, 1 Rogue's Token</li>
+                            <li><strong>Level 60:</strong> Master Thieves — 200 XP, 1 Obsidian Coin</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="panel" data-panel="skill" id="fishing" aria-labelledby="fishing-tab">
+                <header>
+                    <h2>Fishing</h2>
+                    <p>Cast your line into the Moonlit Docks and haul in shimmering catches.</p>
+                </header>
+                <div class="locations">
+                    <article class="location-card">
+                        <h3>Moonlit Docks</h3>
+                        <ul>
+                            <li><strong>Level 1:</strong> Minnow Swarms — 7 XP, 3 Minnows</li>
+                            <li><strong>Level 12:</strong> River Trout — 28 XP, 2 Trout</li>
+                            <li><strong>Level 24:</strong> Seabass Shoals — 55 XP, 2 Seabass</li>
+                            <li><strong>Level 36:</strong> Glowfin Schools — 95 XP, 1 Glowfin</li>
+                        </ul>
+                    </article>
+                    <article class="location-card">
+                        <h3>Tidebreak Reef</h3>
+                        <ul>
+                            <li><strong>Level 48:</strong> Tideclaw Crabs — 150 XP, 2 Tideclaw Meat</li>
+                            <li><strong>Level 60:</strong> Leviathan Echoes — 240 XP, 1 Leviathan Scale</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="panel" data-panel="skill" id="smithing" aria-labelledby="smithing-tab">
+                <header>
+                    <h2>Smithing</h2>
+                    <p>Fire up the Emberforge and craft tools worthy of legends.</p>
+                </header>
+                <div class="locations">
+                    <article class="location-card">
+                        <h3>Emberforge Workshop</h3>
+                        <ul>
+                            <li><strong>Level 1:</strong> Bronze Ingots — 15 XP, 1 Bronze Bar</li>
+                            <li><strong>Level 20:</strong> Iron Tempering — 55 XP, 1 Iron Bar</li>
+                            <li><strong>Level 35:</strong> Steel Folding — 110 XP, 1 Steel Bar</li>
+                            <li><strong>Level 50:</strong> Mithril Bloom — 180 XP, 1 Mithril Bar</li>
+                        </ul>
+                    </article>
+                    <article class="location-card">
+                        <h3>Dragonforge Crucible</h3>
+                        <ul>
+                            <li><strong>Level 65:</strong> Adamant Focus — 260 XP, 1 Adamant Bar</li>
+                            <li><strong>Level 80:</strong> Rune Transmutation — 360 XP, 1 Rune Bar</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="panel" data-panel="skill" id="construction" aria-labelledby="construction-tab">
+                <header>
+                    <h2>Construction</h2>
+                    <p>Build homesteads across the Verdant Frontier and earn settler renown.</p>
+                </header>
+                <div class="locations">
+                    <article class="location-card">
+                        <h3>Verdant Frontier</h3>
+                        <ul>
+                            <li><strong>Level 1:</strong> Starter Shacks — 12 XP, 1 Settler Contract</li>
+                            <li><strong>Level 18:</strong> Timber Lodges — 45 XP, 2 Building Tokens</li>
+                            <li><strong>Level 32:</strong> Manor Foundations — 90 XP, 1 Manor Crest</li>
+                            <li><strong>Level 46:</strong> Guildhall Blueprints — 150 XP, 1 Guild Seal</li>
+                        </ul>
+                    </article>
+                    <article class="location-card">
+                        <h3>Skyspire Bastion</h3>
+                        <ul>
+                            <li><strong>Level 60:</strong> Tower Renovations — 220 XP, 1 Tower Sigil</li>
+                            <li><strong>Level 75:</strong> Aerolith Sanctum — 320 XP, 1 Aerolith Core</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="panel" data-panel="skill" id="cooking" aria-labelledby="cooking-tab">
+                <header>
+                    <h2>Cooking</h2>
+                    <p>Experiment in the Hearthfire Kitchen to create hearty meals.</p>
+                </header>
+                <div class="locations">
+                    <article class="location-card">
+                        <h3>Hearthfire Kitchen</h3>
+                        <ul>
+                            <li><strong>Level 1:</strong> Simple Stew — 6 XP, Restores 5 HP</li>
+                            <li><strong>Level 14:</strong> Honeyed Bread — 24 XP, Restores 10 HP</li>
+                            <li><strong>Level 28:</strong> Seafarer's Pie — 50 XP, Restores 18 HP</li>
+                            <li><strong>Level 42:</strong> Mystic Chowder — 95 XP, Restores 25 HP</li>
+                        </ul>
+                    </article>
+                    <article class="location-card">
+                        <h3>Celestial Banquet</h3>
+                        <ul>
+                            <li><strong>Level 56:</strong> Aurora Skillet — 150 XP, Restores 35 HP</li>
+                            <li><strong>Level 70:</strong> Dragon's Feast — 240 XP, Restores 50 HP</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="panel bank-shop static-panel" id="bank" aria-labelledby="bank-heading">
+                <header>
+                    <h2 id="bank-heading">Bank</h2>
+                    <p>Track your stored items and currency holdings.</p>
+                </header>
+                <div class="inventory-grid">
+                    <div class="inventory-card">
+                        <h3>Ores & Bars</h3>
+                        <ul>
+                            <li>Stone (x120)</li>
+                            <li>Copper Ore (x45)</li>
+                            <li>Iron Bar (x16)</li>
+                            <li>Steel Bar (x4)</li>
+                        </ul>
+                    </div>
+                    <div class="inventory-card">
+                        <h3>Logs & Planks</h3>
+                        <ul>
+                            <li>Birch Logs (x80)</li>
+                            <li>Willow Logs (x32)</li>
+                            <li>Elderwood Heart (x3)</li>
+                        </ul>
+                    </div>
+                    <div class="inventory-card">
+                        <h3>Fish & Food</h3>
+                        <ul>
+                            <li>Minnows (x60)</li>
+                            <li>Glowfin (x8)</li>
+                            <li>Dragon's Feast (x1)</li>
+                        </ul>
+                    </div>
+                    <div class="inventory-card">
+                        <h3>Currency & Curios</h3>
+                        <ul>
+                            <li>Coins (2,450)</li>
+                            <li>Rogue's Token (x5)</li>
+                            <li>Guild Seal (x2)</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <section class="panel bank-shop static-panel" id="shop" aria-labelledby="shop-heading">
+                <header>
+                    <h2 id="shop-heading">Shop</h2>
+                    <p>Upgrade your tools in sequence to unlock higher tier efficiency.</p>
+                </header>
+                <div class="shop-grid">
+                    <article class="shop-category">
+                        <h3>Pickaxes</h3>
+                        <ol class="upgrade-list">
+                            <li class="unlocked">
+                                <span>Bronze Pickaxe</span>
+                                <small>Cost: 150 Coins — Base mining speed.</small>
+                            </li>
+                            <li class="locked" data-requires="Bronze Pickaxe">
+                                <span>Iron Pickaxe</span>
+                                <small>Cost: 450 Coins — +20% ore yield.</small>
+                            </li>
+                            <li class="locked" data-requires="Iron Pickaxe">
+                                <span>Steel Pickaxe</span>
+                                <small>Cost: 900 Coins — +35% ore yield.</small>
+                            </li>
+                            <li class="locked" data-requires="Steel Pickaxe">
+                                <span>Mithril Pickaxe</span>
+                                <small>Cost: 1,500 Coins — +50% ore yield.</small>
+                            </li>
+                        </ol>
+                    </article>
+                    <article class="shop-category">
+                        <h3>Axes</h3>
+                        <ol class="upgrade-list">
+                            <li class="unlocked">
+                                <span>Bronze Axe</span>
+                                <small>Cost: 120 Coins — Cuts basic trees.</small>
+                            </li>
+                            <li class="locked" data-requires="Bronze Axe">
+                                <span>Iron Axe</span>
+                                <small>Cost: 400 Coins — +15% log yield.</small>
+                            </li>
+                            <li class="locked" data-requires="Iron Axe">
+                                <span>Steel Axe</span>
+                                <small>Cost: 850 Coins — +30% log yield.</small>
+                            </li>
+                            <li class="locked" data-requires="Steel Axe">
+                                <span>Runewood Axe</span>
+                                <small>Cost: 1,400 Coins — Unlocks ancient trees.</small>
+                            </li>
+                        </ol>
+                    </article>
+                    <article class="shop-category">
+                        <h3>Fishing Gear</h3>
+                        <ol class="upgrade-list">
+                            <li class="unlocked">
+                                <span>Reed Rod</span>
+                                <small>Cost: 90 Coins — Basic catch rate.</small>
+                            </li>
+                            <li class="locked" data-requires="Reed Rod">
+                                <span>Oak Rod</span>
+                                <small>Cost: 300 Coins — +15% rare catch chance.</small>
+                            </li>
+                            <li class="locked" data-requires="Oak Rod">
+                                <span>Runespun Net</span>
+                                <small>Cost: 780 Coins — +25% rare catch chance.</small>
+                            </li>
+                            <li class="locked" data-requires="Runespun Net">
+                                <span>Leviathan Harpoon</span>
+                                <small>Cost: 1,600 Coins — Unlocks leviathan hunts.</small>
+                            </li>
+                        </ol>
+                    </article>
+                </div>
+            </section>
+        </main>
+    </div>
+    <script src="assets/js/idle.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build the IdleRPG landing page with sidebar navigation, skill panels, and dedicated bank/shop sections
- apply a Runescape/Stardew-inspired visual theme and highlight the link to the Obsidian vault
- implement client-side tab switching with URL hash support and keyboard navigation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e54d558414832e9463b037dc8b74a5