### PR TITLE
Enhance mining location with interactive details

### DIFF
--- a/assets/css/idle.css
+++ b/assets/css/idle.css
@@ -213,6 +213,266 @@ body::before {
     color: var(--accent-emerald);
 }
 
+.mining-layout {
+    margin-top: 1.75rem;
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr);
+    gap: 1.75rem;
+}
+
+.mine-map {
+    position: relative;
+    padding: 1.5rem;
+    border-radius: 18px;
+    border: 1px solid rgba(115, 194, 251, 0.3);
+    background: radial-gradient(circle at top left, rgba(74, 92, 130, 0.45), rgba(25, 30, 47, 0.95));
+    box-shadow: inset 0 0 45px rgba(8, 12, 22, 0.65);
+    overflow: hidden;
+}
+
+.mine-map::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: url('https://www.transparenttextures.com/patterns/rocky-wall.png');
+    opacity: 0.15;
+    pointer-events: none;
+}
+
+.mine-zone-title {
+    margin: 0 0 0.85rem;
+    font-family: var(--font-display);
+    letter-spacing: 0.04em;
+    color: var(--accent-sky);
+    text-shadow: 0 0 12px rgba(115, 194, 251, 0.45);
+    position: relative;
+    z-index: 1;
+}
+
+.mine-node-grid {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.mine-node {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 1rem 1.1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(115, 194, 251, 0.35);
+    background: linear-gradient(145deg, rgba(36, 43, 63, 0.95), rgba(17, 20, 30, 0.9));
+    color: var(--text-primary);
+    font-weight: 600;
+    cursor: pointer;
+    position: relative;
+    isolation: isolate;
+    transition: transform 0.2s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.mine-node::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at top right, rgba(212, 175, 55, 0.22), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    z-index: -1;
+}
+
+.mine-node:hover,
+.mine-node:focus {
+    outline: none;
+    transform: translateY(-3px);
+    border-color: rgba(212, 175, 55, 0.6);
+    box-shadow: 0 12px 22px rgba(10, 16, 32, 0.5);
+}
+
+.mine-node:hover::before,
+.mine-node:focus::before {
+    opacity: 1;
+}
+
+.mine-node.active {
+    border-color: rgba(212, 175, 55, 0.75);
+    box-shadow: 0 0 0 1px rgba(212, 175, 55, 0.6), 0 16px 26px rgba(0, 0, 0, 0.45);
+}
+
+.node-label {
+    font-size: 1.05rem;
+}
+
+.node-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.node-level {
+    color: var(--accent-emerald);
+    font-weight: 700;
+}
+
+.mine-details {
+    position: relative;
+    z-index: 1;
+    padding: 1.75rem 1.5rem;
+    border-radius: 18px;
+    border: 1px solid rgba(212, 175, 55, 0.25);
+    background: linear-gradient(180deg, rgba(37, 44, 66, 0.95) 0%, rgba(18, 22, 34, 0.95) 100%);
+    box-shadow: inset 0 0 42px rgba(6, 10, 20, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.mine-detail-title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 1.4rem;
+    color: var(--accent-gold);
+}
+
+.mine-detail-subtitle {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.mine-detail-description {
+    margin: 0;
+    color: var(--text-primary);
+    line-height: 1.45;
+}
+
+.mine-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.mine-stats div {
+    background: rgba(20, 24, 36, 0.85);
+    border-radius: 12px;
+    padding: 0.75rem;
+    border: 1px solid rgba(115, 194, 251, 0.2);
+    text-align: center;
+}
+
+.mine-stats dt {
+    margin: 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.mine-stats dd {
+    margin: 0.35rem 0 0;
+    font-weight: 700;
+    color: var(--accent-sky);
+    font-size: 1rem;
+}
+
+.mine-start {
+    align-self: flex-start;
+    padding: 0.75rem 1.25rem;
+    border-radius: 12px;
+    border: 1px solid rgba(212, 175, 55, 0.6);
+    background: linear-gradient(90deg, rgba(212, 175, 55, 0.85), rgba(107, 191, 89, 0.85));
+    color: #12141e;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.3s ease;
+}
+
+.mine-start:hover,
+.mine-start:focus {
+    outline: none;
+    transform: translateY(-2px);
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.45);
+}
+
+.mine-start:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    transform: none;
+    box-shadow: none;
+}
+
+.mine-progress {
+    position: relative;
+    width: 100%;
+    height: 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(115, 194, 251, 0.4);
+    background: rgba(16, 20, 30, 0.9);
+    overflow: hidden;
+}
+
+.mine-progress .progress-bar {
+    width: 0%;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(115, 194, 251, 0.9), rgba(107, 191, 89, 0.9));
+    box-shadow: 0 0 16px rgba(115, 194, 251, 0.5);
+    transition: width 0.1s ease;
+}
+
+.mine-status {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.mine-log-wrap {
+    margin-top: 0.5rem;
+}
+
+.mine-log-wrap h4 {
+    margin: 0 0 0.5rem;
+    font-family: var(--font-display);
+    color: var(--accent-gold);
+}
+
+.mine-log {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+    max-height: 160px;
+    overflow-y: auto;
+}
+
+.mine-log li {
+    background: rgba(19, 23, 35, 0.9);
+    border-radius: 10px;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid rgba(115, 194, 251, 0.18);
+    font-size: 0.9rem;
+    color: var(--text-primary);
+}
+
+.mine-log time {
+    display: block;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+}
+}
+
 .bank-shop {
     background: rgba(20, 24, 34, 0.85);
 }
@@ -325,5 +585,13 @@ body::before {
 
     .main-panel {
         padding: 1.5rem;
+    }
+
+    .mining-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .mine-stats {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
 }

--- a/assets/js/idle.js
+++ b/assets/js/idle.js
@@ -55,4 +55,199 @@ document.addEventListener('DOMContentLoaded', () => {
             activateTab(skillPanels[0].id);
         }
     }
+
+    const setupMiningArea = () => {
+        const miningPanel = document.getElementById('mining');
+        if (!miningPanel) {
+            return;
+        }
+
+        const nodeButtons = Array.from(miningPanel.querySelectorAll('.mine-node'));
+        if (!nodeButtons.length) {
+            return;
+        }
+
+        const detailElements = {
+            name: miningPanel.querySelector('[data-mining-detail="name"]'),
+            zone: miningPanel.querySelector('[data-mining-detail="zone"]'),
+            description: miningPanel.querySelector('[data-mining-detail="description"]'),
+            xp: miningPanel.querySelector('[data-mining-detail="xp"]'),
+            resource: miningPanel.querySelector('[data-mining-detail="resource"]'),
+            time: miningPanel.querySelector('[data-mining-detail="time"]'),
+            status: miningPanel.querySelector('[data-mining-detail="status"]'),
+        };
+
+        const progressContainer = miningPanel.querySelector('.mine-progress');
+        const progressBar = miningPanel.querySelector('.mine-progress .progress-bar');
+        const startButton = miningPanel.querySelector('.mine-start');
+        const logList = miningPanel.querySelector('.mine-log');
+
+        let selectedNode = nodeButtons.find((button) => button.classList.contains('active')) || nodeButtons[0];
+        let miningFrame = null;
+        let miningDuration = 0;
+        let miningStart = 0;
+
+        const formatSeconds = (value) => {
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric) || numeric <= 0) {
+                return 'Instant';
+            }
+            return Number.isInteger(numeric) ? `${numeric}s` : `${numeric.toFixed(1)}s`;
+        };
+
+        const updateStatus = (message) => {
+            if (detailElements.status) {
+                detailElements.status.textContent = message;
+            }
+        };
+
+        const updateProgress = (percentage) => {
+            if (!progressBar || !progressContainer) {
+                return;
+            }
+            const safePercentage = Math.max(0, Math.min(100, percentage));
+            progressBar.style.width = `${safePercentage}%`;
+            progressContainer.setAttribute('aria-valuenow', String(Math.round(safePercentage)));
+            progressContainer.setAttribute('aria-valuetext', `${Math.round(safePercentage)} percent`);
+        };
+
+        const updateDetails = (node) => {
+            if (!node) {
+                return;
+            }
+
+            if (detailElements.name) {
+                detailElements.name.textContent = node.dataset.node || node.textContent.trim();
+            }
+            if (detailElements.zone) {
+                const zone = node.dataset.zone || 'Unknown Vein';
+                const level = node.dataset.level ? ` • Recommended Level ${node.dataset.level}` : '';
+                detailElements.zone.textContent = `${zone}${level}`;
+            }
+            if (detailElements.description) {
+                detailElements.description.textContent = node.dataset.description || '';
+            }
+            if (detailElements.xp) {
+                detailElements.xp.textContent = node.dataset.xp || '—';
+            }
+            if (detailElements.resource) {
+                detailElements.resource.textContent = node.dataset.resource || '—';
+            }
+            if (detailElements.time) {
+                detailElements.time.textContent = formatSeconds(node.dataset.time);
+            }
+        };
+
+        const resetProgress = () => {
+            updateProgress(0);
+            if (startButton) {
+                startButton.disabled = false;
+                startButton.textContent = 'Start Mining';
+            }
+            updateStatus('Ready to swing your pickaxe.');
+        };
+
+        const selectNode = (node) => {
+            if (!node || node === selectedNode || miningFrame) {
+                return;
+            }
+            nodeButtons.forEach((button) => {
+                button.classList.toggle('active', button === node);
+            });
+            selectedNode = node;
+            updateDetails(node);
+            resetProgress();
+        };
+
+        const addLogEntry = (node) => {
+            if (!logList) {
+                return;
+            }
+            const entry = document.createElement('li');
+            const timestamp = document.createElement('time');
+            const now = new Date();
+            timestamp.dateTime = now.toISOString();
+            timestamp.textContent = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+            const summary = document.createElement('span');
+            const resource = node.dataset.resource || 'Unknown loot';
+            const xp = node.dataset.xp || '';
+            summary.textContent = `${resource} • ${xp}`;
+            entry.append(timestamp, summary);
+            logList.prepend(entry);
+            const maxEntries = 6;
+            while (logList.children.length > maxEntries) {
+                logList.removeChild(logList.lastElementChild);
+            }
+        };
+
+        const finishMining = () => {
+            miningFrame = null;
+            miningStart = 0;
+            updateProgress(100);
+            if (startButton) {
+                startButton.disabled = false;
+                startButton.textContent = 'Start Mining';
+            }
+            addLogEntry(selectedNode);
+            const nodeName = selectedNode.dataset.node || 'the vein';
+            const resource = selectedNode.dataset.resource || 'loot';
+            const xp = selectedNode.dataset.xp || ''; 
+            const xpText = xp ? ` and gained ${xp}` : '';
+            updateStatus(`You mined ${resource} from ${nodeName}${xpText ? `${xpText}.` : '.'}`);
+        };
+
+        const step = (timestamp) => {
+            if (!miningStart) {
+                miningStart = timestamp;
+            }
+            const elapsed = timestamp - miningStart;
+            const progress = Math.min(1, elapsed / miningDuration);
+            updateProgress(progress * 100);
+
+            if (progress >= 1) {
+                finishMining();
+                return;
+            }
+            miningFrame = window.requestAnimationFrame(step);
+        };
+
+        const startMining = () => {
+            if (!selectedNode || miningFrame) {
+                updateStatus('You are already mining...');
+                return;
+            }
+            const cycleTime = Number(selectedNode.dataset.time) || 6;
+            miningDuration = Math.max(1000, cycleTime * 1000);
+            miningStart = 0;
+            updateProgress(0);
+            updateStatus('Swinging your pickaxe...');
+            if (startButton) {
+                startButton.disabled = true;
+                startButton.textContent = 'Mining...';
+            }
+            miningFrame = window.requestAnimationFrame(step);
+        };
+
+        nodeButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                selectNode(button);
+            });
+            button.addEventListener('keydown', (event) => {
+                if (event.key !== 'Enter' && event.key !== ' ') {
+                    return;
+                }
+                event.preventDefault();
+                selectNode(button);
+            });
+        });
+
+        if (startButton) {
+            startButton.addEventListener('click', startMining);
+        }
+
+        updateDetails(selectedNode);
+        resetProgress();
+    };
+
+    setupMiningArea();
 });

--- a/index.html
+++ b/index.html
@@ -37,24 +37,108 @@
                     <h2>Mining</h2>
                     <p>Delve into the Stonefall Quarry and excavate rich veins of ore.</p>
                 </header>
-                <div class="locations">
-                    <article class="location-card">
-                        <h3>Stonefall Quarry</h3>
-                        <ul>
-                            <li><strong>Level 1:</strong> Shallow Pebble Patches — 10 XP, 3 Stone</li>
-                            <li><strong>Level 10:</strong> Copper Veins — 35 XP, 1 Copper Ore</li>
-                            <li><strong>Level 20:</strong> Iron Strata — 60 XP, 1 Iron Ore</li>
-                            <li><strong>Level 30:</strong> Silver Shard Crest — 120 XP, 1 Silver Ore</li>
-                        </ul>
-                    </article>
-                    <article class="location-card">
-                        <h3>Obsidian Breach</h3>
-                        <ul>
-                            <li><strong>Level 40:</strong> Basalt Clusters — 180 XP, 2 Basalt</li>
-                            <li><strong>Level 50:</strong> Obsidian Spurs — 260 XP, 1 Obsidian</li>
-                            <li><strong>Level 60:</strong> Dragonstone Geodes — 360 XP, 1 Dragonstone Shard</li>
-                        </ul>
-                    </article>
+                <div class="mining-layout">
+                    <div class="mine-map" aria-label="Mining nodes" role="list">
+                        <h3 class="mine-zone-title">Stonefall Quarry</h3>
+                        <div class="mine-node-grid" role="group" aria-label="Stonefall Quarry nodes">
+                            <button class="mine-node active" type="button" role="listitem"
+                                data-node="Shallow Pebble Patches" data-zone="Stonefall Quarry" data-level="1" data-xp="10 XP"
+                                data-resource="3× Stone" data-time="4" data-description="Loose rocks just below the surface. Great for beginners to learn the rhythm of mining without heavy strain.">
+                                <span class="node-label">Shallow Pebble Patches</span>
+                                <span class="node-meta">
+                                    <span class="node-level">Level 1</span>
+                                    <span class="node-reward">10 XP • 3× Stone</span>
+                                </span>
+                            </button>
+                            <button class="mine-node" type="button" role="listitem"
+                                data-node="Copper Veins" data-zone="Stonefall Quarry" data-level="10" data-xp="35 XP"
+                                data-resource="1× Copper Ore" data-time="6" data-description="A dependable vein of copper that glows warm in the lantern light. Favoured by smiths looking for fast bars.">
+                                <span class="node-label">Copper Veins</span>
+                                <span class="node-meta">
+                                    <span class="node-level">Level 10</span>
+                                    <span class="node-reward">35 XP • 1× Copper Ore</span>
+                                </span>
+                            </button>
+                            <button class="mine-node" type="button" role="listitem"
+                                data-node="Iron Strata" data-zone="Stonefall Quarry" data-level="20" data-xp="60 XP"
+                                data-resource="1× Iron Ore" data-time="7.5" data-description="Dense layers of iron hidden behind tougher stone. Requires patience but rewards a steady stream of ore.">
+                                <span class="node-label">Iron Strata</span>
+                                <span class="node-meta">
+                                    <span class="node-level">Level 20</span>
+                                    <span class="node-reward">60 XP • 1× Iron Ore</span>
+                                </span>
+                            </button>
+                            <button class="mine-node" type="button" role="listitem"
+                                data-node="Silver Shard Crest" data-zone="Stonefall Quarry" data-level="30" data-xp="120 XP"
+                                data-resource="1× Silver Ore" data-time="9" data-description="The upper ridge of the quarry sparkles with shards of pure silver. A showpiece node with higher risk, higher reward.">
+                                <span class="node-label">Silver Shard Crest</span>
+                                <span class="node-meta">
+                                    <span class="node-level">Level 30</span>
+                                    <span class="node-reward">120 XP • 1× Silver Ore</span>
+                                </span>
+                            </button>
+                        </div>
+
+                        <h3 class="mine-zone-title">Obsidian Breach</h3>
+                        <div class="mine-node-grid" role="group" aria-label="Obsidian Breach nodes">
+                            <button class="mine-node" type="button" role="listitem"
+                                data-node="Basalt Clusters" data-zone="Obsidian Breach" data-level="40" data-xp="180 XP"
+                                data-resource="2× Basalt" data-time="10" data-description="Volcanic stone cooled into smooth hexagons. Breaking them free reveals pockets of crystallised heat.">
+                                <span class="node-label">Basalt Clusters</span>
+                                <span class="node-meta">
+                                    <span class="node-level">Level 40</span>
+                                    <span class="node-reward">180 XP • 2× Basalt</span>
+                                </span>
+                            </button>
+                            <button class="mine-node" type="button" role="listitem"
+                                data-node="Obsidian Spurs" data-zone="Obsidian Breach" data-level="50" data-xp="260 XP"
+                                data-resource="1× Obsidian" data-time="12" data-description="Jagged glass-like formations jut from the cavern wall. Handle with care to claim gleaming obsidian shards.">
+                                <span class="node-label">Obsidian Spurs</span>
+                                <span class="node-meta">
+                                    <span class="node-level">Level 50</span>
+                                    <span class="node-reward">260 XP • 1× Obsidian</span>
+                                </span>
+                            </button>
+                            <button class="mine-node" type="button" role="listitem"
+                                data-node="Dragonstone Geodes" data-zone="Obsidian Breach" data-level="60" data-xp="360 XP"
+                                data-resource="1× Dragonstone Shard" data-time="14" data-description="Massive geodes hum with a faint resonance. Splitting them open may uncover rare dragonstone fragments.">
+                                <span class="node-label">Dragonstone Geodes</span>
+                                <span class="node-meta">
+                                    <span class="node-level">Level 60</span>
+                                    <span class="node-reward">360 XP • 1× Dragonstone Shard</span>
+                                </span>
+                            </button>
+                        </div>
+                    </div>
+                    <aside class="mine-details" aria-live="polite">
+                        <h3>Vein Overview</h3>
+                        <p class="mine-detail-title" data-mining-detail="name">Shallow Pebble Patches</p>
+                        <p class="mine-detail-subtitle" data-mining-detail="zone">Stonefall Quarry • Recommended Level 1</p>
+                        <p class="mine-detail-description" data-mining-detail="description">Loose rocks just below the surface. Great for beginners to learn the rhythm of mining without heavy strain.</p>
+                        <dl class="mine-stats">
+                            <div>
+                                <dt>XP</dt>
+                                <dd data-mining-detail="xp">10 XP</dd>
+                            </div>
+                            <div>
+                                <dt>Resources</dt>
+                                <dd data-mining-detail="resource">3× Stone</dd>
+                            </div>
+                            <div>
+                                <dt>Cycle Time</dt>
+                                <dd data-mining-detail="time">4s</dd>
+                            </div>
+                        </dl>
+                        <button class="mine-start" type="button">Start Mining</button>
+                        <div class="mine-progress" role="progressbar" aria-live="assertive" aria-label="Mining progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                            <div class="progress-bar"></div>
+                        </div>
+                        <p class="mine-status" data-mining-detail="status">Ready to swing your pickaxe.</p>
+                        <div class="mine-log-wrap">
+                            <h4>Recent Hauls</h4>
+                            <ul class="mine-log" aria-live="polite" aria-label="Mining log"></ul>
+                        </div>
+                    </aside>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- redesign the mining panel with clickable nodes, a vein overview sidebar, and richer narrative descriptions
- refresh IdleRPG styles to give the mining area bespoke theming while retaining bank/shop visuals
- add client-side logic for node selection, progress simulation, and a mining haul log

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54a22db58832e8cd88ba20786d8df