### PR TITLE
Add static catalogs and shared types

### DIFF
--- a/app/hooks/useCatalog.ts
+++ b/app/hooks/useCatalog.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import { getComponents, getMicrocontrollers } from "@/lib/catalog";
+import type { Component, Microcontroller } from "@/types";
+
+interface CatalogData {
+  microcontrollers: Microcontroller[];
+  components: Component[];
+}
+
+export function useCatalog(): CatalogData {
+  return useMemo(
+    () => ({
+      microcontrollers: getMicrocontrollers(),
+      components: getComponents(),
+    }),
+    []
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,10 @@
+"use client";
+
+import { useCatalog } from "./hooks/useCatalog";
+
 export default function HomePage() {
+  const { microcontrollers, components } = useCatalog();
+
   return (
     <main className="min-h-screen flex flex-col">
       {/* Top nav */}
@@ -35,9 +41,46 @@ export default function HomePage() {
               <h3 className="text-xs font-semibold text-slate-400 mb-2">
                 Microcontroller
               </h3>
-              <div className="border border-dashed border-slate-700 rounded-xl p-4 text-xs text-slate-400">
-                This is where you&apos;ll choose a base MCU (ESP32, Arduino Uno,
-                Raspberry Pi Pico, etc.) and see its core specs.
+              <div className="grid gap-3 sm:grid-cols-2">
+                {microcontrollers.map((mcu) => (
+                  <div
+                    key={mcu.id}
+                    className="rounded-xl border border-slate-800 bg-slate-900/70 p-3 shadow-sm hover:border-emerald-500/50 transition"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-semibold text-slate-100">
+                          {mcu.name}
+                        </p>
+                        <p className="text-[11px] text-slate-400">{mcu.id}</p>
+                      </div>
+                      <span className="rounded-lg bg-emerald-500/10 px-2 py-1 text-[11px] font-semibold text-emerald-300">
+                        {mcu.voltage}V
+                      </span>
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-slate-300">
+                      <span className="rounded-full bg-slate-800 px-2 py-1">
+                        {mcu.gpioCount} GPIO
+                      </span>
+                      <span className="rounded-full bg-slate-800 px-2 py-1">
+                        {mcu.maxCurrent} mA max
+                      </span>
+                    </div>
+                    <div className="mt-2 text-[11px] text-slate-400 flex flex-wrap gap-1">
+                      {mcu.protocols.map((protocol) => (
+                        <span
+                          key={protocol}
+                          className="rounded-full bg-slate-800 px-2 py-1 capitalize"
+                        >
+                          {protocol}
+                        </span>
+                      ))}
+                    </div>
+                    {mcu.notes ? (
+                      <p className="mt-2 text-[11px] text-slate-500">{mcu.notes}</p>
+                    ) : null}
+                  </div>
+                ))}
               </div>
             </div>
 
@@ -45,15 +88,46 @@ export default function HomePage() {
               <h3 className="text-xs font-semibold text-slate-400 mb-2">
                 Components
               </h3>
-              <div className="border border-dashed border-slate-700 rounded-xl p-4 space-y-2 text-xs text-slate-400">
-                <p>
-                  Here you&apos;ll search and add sensors, power modules,
-                  communication modules, and actuators to your build.
-                </p>
-                <p className="text-slate-500">
-                  For now this is just a static placeholder. Next iterations
-                  will add real data and state.
-                </p>
+              <div className="grid gap-3 md:grid-cols-2">
+                {components.map((component) => (
+                  <div
+                    key={component.id}
+                    className="rounded-xl border border-slate-800 bg-slate-900/70 p-3 text-xs text-slate-200 shadow-sm hover:border-sky-400/50 transition"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-slate-100">
+                          {component.name}
+                        </p>
+                        <p className="text-[11px] uppercase tracking-wide text-slate-500">
+                          {component.category}
+                        </p>
+                      </div>
+                      <span className="rounded-lg bg-slate-800 px-2 py-1 text-[11px] text-slate-200">
+                        {component.voltage}V
+                      </span>
+                    </div>
+                    <p className="mt-1 text-[11px] text-slate-400">
+                      {component.description}
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-slate-300">
+                      <span className="rounded-full bg-slate-800 px-2 py-1 capitalize">
+                        {component.protocol}
+                      </span>
+                      <span className="rounded-full bg-slate-800 px-2 py-1">
+                        {component.requiredPins} pin{component.requiredPins !== 1 ? "s" : ""}
+                      </span>
+                      <span className="rounded-full bg-slate-800 px-2 py-1">
+                        ~{component.estimatedCurrent} mA
+                      </span>
+                      {component.i2cAddress ? (
+                        <span className="rounded-full bg-slate-800 px-2 py-1">
+                          I2C {component.i2cAddress}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           </div>

--- a/data/components.json
+++ b/data/components.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "dht22-temp-humidity",
+    "name": "DHT22 Temperature/Humidity",
+    "category": "sensor",
+    "voltage": 3.3,
+    "protocol": "digital",
+    "estimatedCurrent": 2,
+    "requiredPins": 1,
+    "vendor": "Aosong",
+    "description": "Digital temperature and humidity sensor"
+  },
+  {
+    "id": "bme280-env",
+    "name": "BME280 Environmental Sensor",
+    "category": "sensor",
+    "voltage": 3.3,
+    "protocol": "i2c",
+    "estimatedCurrent": 1,
+    "requiredPins": 2,
+    "i2cAddress": "0x76",
+    "vendor": "Bosch",
+    "description": "Temperature, humidity, and pressure sensor"
+  },
+  {
+    "id": "mpu6050-imu",
+    "name": "MPU-6050 6DoF IMU",
+    "category": "sensor",
+    "voltage": 3.3,
+    "protocol": "i2c",
+    "estimatedCurrent": 3,
+    "requiredPins": 2,
+    "i2cAddress": "0x68",
+    "vendor": "InvenSense",
+    "description": "Accelerometer and gyroscope module"
+  },
+  {
+    "id": "ssd1306-oled",
+    "name": "SSD1306 0.96\" OLED Display",
+    "category": "misc",
+    "voltage": 3.3,
+    "protocol": "i2c",
+    "estimatedCurrent": 20,
+    "requiredPins": 2,
+    "i2cAddress": "0x3C",
+    "vendor": "Generic",
+    "description": "128x64 monochrome display"
+  },
+  {
+    "id": "hc05-bluetooth",
+    "name": "HC-05 Bluetooth Module",
+    "category": "communication",
+    "voltage": 5,
+    "protocol": "uart",
+    "estimatedCurrent": 30,
+    "requiredPins": 2,
+    "vendor": "Generic",
+    "description": "Classic Bluetooth serial module"
+  },
+  {
+    "id": "nrf24l01-radio",
+    "name": "nRF24L01+ Radio",
+    "category": "communication",
+    "voltage": 3.3,
+    "protocol": "spi",
+    "estimatedCurrent": 15,
+    "requiredPins": 5,
+    "vendor": "Nordic",
+    "description": "2.4GHz wireless transceiver"
+  },
+  {
+    "id": "buck-step-down",
+    "name": "3A Buck Converter",
+    "category": "power",
+    "voltage": 5,
+    "protocol": "analog",
+    "estimatedCurrent": 0,
+    "requiredPins": 0,
+    "vendor": "Generic",
+    "description": "Step-down regulator for powering 5V peripherals"
+  },
+  {
+    "id": "sg90-servo",
+    "name": "SG90 Micro Servo",
+    "category": "actuator",
+    "voltage": 5,
+    "protocol": "digital",
+    "estimatedCurrent": 250,
+    "requiredPins": 1,
+    "vendor": "TowerPro",
+    "description": "Miniature hobby servo motor"
+  },
+  {
+    "id": "ws2812b-strip",
+    "name": "WS2812B LED Strip (30/m)",
+    "category": "actuator",
+    "voltage": 5,
+    "protocol": "digital",
+    "estimatedCurrent": 1800,
+    "requiredPins": 1,
+    "vendor": "Adafruit",
+    "description": "Individually addressable RGB LEDs"
+  },
+  {
+    "id": "tp4056-lipo-charger",
+    "name": "TP4056 LiPo Charger",
+    "category": "power",
+    "voltage": 5,
+    "protocol": "analog",
+    "estimatedCurrent": 0,
+    "requiredPins": 0,
+    "vendor": "Generic",
+    "description": "Lithium battery charging module"
+  }
+]

--- a/data/mcus.json
+++ b/data/mcus.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "esp32-devkit-v1",
+    "name": "ESP32 DevKit V1",
+    "voltage": 3.3,
+    "gpioCount": 30,
+    "protocols": ["i2c", "spi", "uart", "analog", "digital"],
+    "maxCurrent": 500,
+    "notes": "Dual-core, Wi-Fi/Bluetooth, common development board layout"
+  },
+  {
+    "id": "arduino-uno-r3",
+    "name": "Arduino Uno R3",
+    "voltage": 5,
+    "gpioCount": 14,
+    "protocols": ["i2c", "spi", "uart", "analog", "digital"],
+    "maxCurrent": 200,
+    "notes": "5V logic, classic ATmega328P"
+  },
+  {
+    "id": "raspberry-pi-pico",
+    "name": "Raspberry Pi Pico",
+    "voltage": 3.3,
+    "gpioCount": 26,
+    "protocols": ["i2c", "spi", "uart", "analog", "digital"],
+    "maxCurrent": 300,
+    "notes": "RP2040 dual-core with flexible I/O"
+  },
+  {
+    "id": "teensy-4-1",
+    "name": "Teensy 4.1",
+    "voltage": 3.3,
+    "gpioCount": 55,
+    "protocols": ["i2c", "spi", "uart", "analog", "digital"],
+    "maxCurrent": 800,
+    "notes": "High-performance ARM Cortex-M7"
+  }
+]

--- a/lib/catalog.ts
+++ b/lib/catalog.ts
@@ -1,0 +1,11 @@
+import components from "@/data/components.json";
+import microcontrollers from "@/data/mcus.json";
+import type { Component, Microcontroller } from "@/types";
+
+export function getMicrocontrollers(): Microcontroller[] {
+  return microcontrollers as Microcontroller[];
+}
+
+export function getComponents(): Component[] {
+  return components as Component[];
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,46 @@
+export type Protocol = "i2c" | "spi" | "uart" | "analog" | "digital";
+
+export type ComponentCategory =
+  | "sensor"
+  | "communication"
+  | "power"
+  | "actuator"
+  | "misc";
+
+export interface Microcontroller {
+  id: string;
+  name: string;
+  voltage: number;
+  gpioCount: number;
+  protocols: Protocol[];
+  maxCurrent: number;
+  notes?: string;
+}
+
+export interface Component {
+  id: string;
+  name: string;
+  category: ComponentCategory;
+  voltage: number;
+  protocol: Protocol;
+  estimatedCurrent: number;
+  requiredPins: number;
+  i2cAddress?: string;
+  vendor?: string;
+  description?: string;
+}
+
+export interface BuildState {
+  microcontroller?: Microcontroller;
+  components: Component[];
+}
+
+export type ValidationSeverity = "error" | "warning";
+
+export interface ValidationResult {
+  id: string;
+  ruleId: string;
+  severity: ValidationSeverity;
+  message: string;
+  relatedIds?: string[];
+}


### PR DESCRIPTION
## Summary
- add shared BoardBuilder types for protocols, components, build state, and validation results
- seed static MCU and component catalogs for initial UI data
- add catalog helper and hook and render the data in the configuration panel

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b2cafa74832e96cd21d528efed04)