### PR TITLE
Add realistic esk8 catalogs and surface specs in UI

### DIFF
--- a/data/batteries.json
+++ b/data/batteries.json
@@ -6,16 +6,24 @@
     "capacityWh": 400,
     "voltageClass": "10S",
     "continuousDischargeA": 60,
-    "notes": "Balanced range for daily riding."
+    "configuration": "10S3P 21700",
+    "cellFormat": "21700",
+    "smartBms": true,
+    "notes": "Balanced range for daily riding with built-in BMS telemetry.",
+    "tags": ["commuter", "beginner"]
   },
   {
-    "id": "battery-12s-500",
-    "name": "12S 500Wh Performance Pack",
+    "id": "battery-12s-540",
+    "name": "12S 540Wh Performance Pack",
     "category": "battery",
-    "capacityWh": 500,
+    "capacityWh": 540,
     "voltageClass": "12S",
-    "continuousDischargeA": 80,
-    "notes": "High-voltage pack for strong acceleration."
+    "continuousDischargeA": 90,
+    "configuration": "12S3P 21700",
+    "cellFormat": "21700",
+    "smartBms": true,
+    "notes": "High-voltage pack for strong acceleration and braking headroom.",
+    "tags": ["speed", "performance"]
   },
   {
     "id": "battery-8s-320",
@@ -24,6 +32,23 @@
     "capacityWh": 320,
     "voltageClass": "8S",
     "continuousDischargeA": 50,
-    "notes": "Lightweight pack for compact builds."
+    "configuration": "8S2P 18650",
+    "cellFormat": "18650",
+    "smartBms": false,
+    "notes": "Lightweight pack for compact travel boards.",
+    "tags": ["commuter", "budget", "travel"]
+  },
+  {
+    "id": "battery-10s-450",
+    "name": "10S 450Wh Trail Pack",
+    "category": "battery",
+    "capacityWh": 450,
+    "voltageClass": "10S",
+    "continuousDischargeA": 70,
+    "configuration": "10S3P 18650",
+    "cellFormat": "18650",
+    "smartBms": false,
+    "notes": "Ruggedized enclosure for mixed-surface commuting.",
+    "tags": ["off-road", "adventure"]
   }
 ]

--- a/data/decks.json
+++ b/data/decks.json
@@ -1,29 +1,54 @@
 [
   {
     "id": "deck-commuter-38",
-    "name": "Commuter 38\" Top-Mount",
+    "name": "38\" Commuter Top-Mount",
     "category": "deck",
     "lengthCm": 97,
+    "wheelbaseCm": 70,
+    "widthCm": 23.5,
     "flex": "medium",
     "mountStyle": "top-mount",
-    "notes": "Stable carving deck with mellow concave."
+    "deckStyle": "commuter",
+    "notes": "Stable carving deck with mellow concave and foot-stop friendly nose.",
+    "tags": ["commuter", "beginner", "carve"]
   },
   {
     "id": "deck-drop-40",
-    "name": "Drop-Through 40\" Cruiser",
+    "name": "40\" Drop-Through Cruiser",
     "category": "deck",
     "lengthCm": 102,
+    "wheelbaseCm": 75,
+    "widthCm": 24,
     "flex": "flexy",
     "mountStyle": "drop-through",
-    "notes": "Lower ride height for push-friendly commuting."
+    "deckStyle": "cruiser",
+    "notes": "Lower ride height for push-friendly commuting and smooth carving.",
+    "tags": ["commuter", "comfort", "beginner"]
   },
   {
     "id": "deck-downhill-37",
-    "name": "Downhill 37\" Stiff",
+    "name": "37\" Downhill Stiff",
     "category": "deck",
     "lengthCm": 94,
+    "wheelbaseCm": 68,
+    "widthCm": 23,
     "flex": "stiff",
     "mountStyle": "top-mount",
-    "notes": "Locked-in stance for high-speed stability."
+    "deckStyle": "downhill",
+    "notes": "Locked-in stance with micro-drop pockets for high-speed stability.",
+    "tags": ["speed", "downhill"]
+  },
+  {
+    "id": "deck-dropdeck-39",
+    "name": "39\" Drop-Deck Carver",
+    "category": "deck",
+    "lengthCm": 99,
+    "wheelbaseCm": 72,
+    "widthCm": 23.5,
+    "flex": "medium",
+    "mountStyle": "drop-deck",
+    "deckStyle": "carver",
+    "notes": "Sunken platform with rocker for locked-in commuting and carving.",
+    "tags": ["commuter", "comfort", "carve"]
   }
 ]

--- a/data/driveKits.json
+++ b/data/driveKits.json
@@ -1,32 +1,44 @@
 [
   {
     "id": "drivekit-ht-170",
-    "name": "170KV Torque Drive",
+    "name": "170KV Torque Belt Drive",
     "category": "drive_kit",
     "kv": 170,
     "supportedVoltageClasses": ["8S", "10S"],
     "maxPowerW": 2800,
     "profile": "high_torque",
-    "notes": "Geared for hill climbing and heavier riders."
+    "driveType": "belt",
+    "ratio": "15/36",
+    "wheelCompatibility": "90-110mm street",
+    "notes": "Geared for hill climbing and heavier riders.",
+    "tags": ["commuter", "hill", "cargo"]
   },
   {
     "id": "drivekit-balanced-190",
-    "name": "190KV Balanced Drive",
+    "name": "190KV Sealed Gear Drive",
     "category": "drive_kit",
     "kv": 190,
     "supportedVoltageClasses": ["10S", "12S"],
     "maxPowerW": 3200,
     "profile": "balanced",
-    "notes": "Blend of acceleration and top speed."
+    "driveType": "gear",
+    "ratio": "2.4:1",
+    "wheelCompatibility": "97-110mm street/AT",
+    "notes": "Blend of acceleration and top speed with low maintenance.",
+    "tags": ["performance", "speed"]
   },
   {
     "id": "drivekit-speed-200",
-    "name": "200KV Speed Drive",
+    "name": "200KV Stealth Hub Set",
     "category": "drive_kit",
     "kv": 200,
     "supportedVoltageClasses": ["10S", "12S"],
-    "maxPowerW": 3400,
+    "maxPowerW": 3000,
     "profile": "high_speed",
-    "notes": "Optimized for fast flats."
+    "driveType": "hub",
+    "ratio": "direct",
+    "wheelCompatibility": "90-105mm street",
+    "notes": "Low-drag hub motors optimized for fast flats.",
+    "tags": ["speed", "stealth"]
   }
 ]

--- a/data/escs.json
+++ b/data/escs.json
@@ -1,12 +1,17 @@
 [
   {
     "id": "esc-dual-10s",
-    "name": "Dual ESC 10S Ready",
+    "name": "Dual Touring ESC (8S/10S)",
     "category": "esc",
     "supportedVoltageClasses": ["8S", "10S"],
     "maxContinuousCurrentA": 60,
     "motorCount": "dual",
-    "notes": "Great for 2WD commuter setups."
+    "connectors": ["MR60", "sensor"],
+    "hasBluetooth": true,
+    "hasTelemetry": true,
+    "waterproofRating": "IP65",
+    "notes": "Great for 2WD commuter setups with app tuning.",
+    "tags": ["commuter", "beginner"]
   },
   {
     "id": "esc-performance-12s",
@@ -14,16 +19,26 @@
     "category": "esc",
     "supportedVoltageClasses": ["10S", "12S"],
     "maxContinuousCurrentA": 80,
-    "motorCount": "single",
-    "notes": "Designed for high-voltage builds."
+    "motorCount": "dual",
+    "connectors": ["QS8", "sensor"],
+    "hasBluetooth": true,
+    "hasTelemetry": true,
+    "waterproofRating": "IP67",
+    "notes": "Designed for high-voltage builds with active cooling path.",
+    "tags": ["speed", "performance"]
   },
   {
     "id": "esc-urban-8s",
-    "name": "Urban ESC 8S",
+    "name": "Compact ESC 6S/8S",
     "category": "esc",
     "supportedVoltageClasses": ["6S", "8S"],
     "maxContinuousCurrentA": 50,
     "motorCount": "single",
-    "notes": "Efficient controller for lightweight boards."
+    "connectors": ["XT60"],
+    "hasBluetooth": false,
+    "hasTelemetry": false,
+    "waterproofRating": "IP54",
+    "notes": "Efficient controller for lightweight boards and travel builds.",
+    "tags": ["commuter", "budget", "travel"]
   }
 ]

--- a/data/remotes.json
+++ b/data/remotes.json
@@ -5,15 +5,25 @@
     "category": "remote",
     "frequency": "2.4GHz",
     "compatibleEscFamilies": ["VESC-style", "Hobby dual"],
-    "notes": "Basic throttle with cruise toggle."
+    "triggerStyle": "trigger",
+    "hasTelemetry": false,
+    "ridingModes": 2,
+    "waterproofRating": "IP54",
+    "notes": "Basic throttle with cruise toggle.",
+    "tags": ["beginner", "budget"]
   },
   {
     "id": "remote-telemetry",
-    "name": "Telemetry Remote",
+    "name": "Telemetry GT Remote",
     "category": "remote",
     "frequency": "2.4GHz",
     "compatibleEscFamilies": ["VESC-style"],
-    "notes": "Displays speed and battery status."
+    "triggerStyle": "trigger",
+    "hasTelemetry": true,
+    "ridingModes": 4,
+    "waterproofRating": "IP55",
+    "notes": "Displays speed and battery status with haptic alerts.",
+    "tags": ["performance", "speed"]
   },
   {
     "id": "remote-compact",
@@ -21,6 +31,11 @@
     "category": "remote",
     "frequency": "2.4GHz",
     "compatibleEscFamilies": ["Light ESC"],
-    "notes": "Pocketable remote for travel boards."
+    "triggerStyle": "thumbwheel",
+    "hasTelemetry": false,
+    "ridingModes": 2,
+    "waterproofRating": "IPX4",
+    "notes": "Pocketable remote for travel boards.",
+    "tags": ["travel", "commuter"]
   }
 ]

--- a/data/trucks.json
+++ b/data/trucks.json
@@ -1,29 +1,38 @@
 [
   {
     "id": "trucks-rkp-180",
-    "name": "180mm RKP Carve",
+    "name": "180mm 50° RKP Carve",
     "category": "trucks",
     "widthMm": 180,
     "truckType": "RKP",
     "mountCompatibility": ["top-mount", "drop-through"],
-    "notes": "Responsive turning with stable center."
+    "baseplateAngleDeg": 50,
+    "axleDiameterMm": 8,
+    "notes": "Responsive turning with stable center and tall bushings.",
+    "tags": ["carve", "commuter"]
   },
   {
     "id": "trucks-pkp-170",
-    "name": "170mm PKP Street",
+    "name": "170mm 44° PKP Street",
     "category": "trucks",
     "widthMm": 170,
     "truckType": "PKP",
     "mountCompatibility": ["top-mount"],
-    "notes": "Low ride height and quick lean for urban riding."
+    "baseplateAngleDeg": 44,
+    "axleDiameterMm": 8,
+    "notes": "Low ride height and quick lean for urban riding.",
+    "tags": ["commuter", "budget"]
   },
   {
     "id": "trucks-rkp-184",
-    "name": "184mm RKP Downhill",
+    "name": "184mm 45° Precision RKP",
     "category": "trucks",
     "widthMm": 184,
     "truckType": "RKP",
     "mountCompatibility": ["top-mount"],
-    "notes": "Precision feel for speed-focused builds."
+    "baseplateAngleDeg": 45,
+    "axleDiameterMm": 8,
+    "notes": "CNC hangers with tight tolerances for speed-focused builds.",
+    "tags": ["speed", "downhill"]
   }
 ]

--- a/data/wheels.json
+++ b/data/wheels.json
@@ -6,8 +6,11 @@
     "diameterMm": 90,
     "hardnessA": 78,
     "contactPatchMm": 56,
+    "widthMm": 52,
     "wheelType": "street",
-    "notes": "Grippy urethane for smooth pavement."
+    "lipShape": "square",
+    "notes": "Grippy urethane for smooth pavement.",
+    "tags": ["commuter", "carve"]
   },
   {
     "id": "wheels-street-97",
@@ -16,8 +19,24 @@
     "diameterMm": 97,
     "hardnessA": 76,
     "contactPatchMm": 60,
+    "widthMm": 55,
     "wheelType": "street",
-    "notes": "Extra damping for rougher bike paths."
+    "lipShape": "rounded",
+    "notes": "Extra damping for rougher bike paths.",
+    "tags": ["commuter", "comfort"]
+  },
+  {
+    "id": "wheels-at-105",
+    "name": "105mm Cloud Hybrid",
+    "category": "wheels",
+    "diameterMm": 105,
+    "hardnessA": 78,
+    "contactPatchMm": 62,
+    "widthMm": 60,
+    "wheelType": "all-terrain",
+    "lipShape": "rounded",
+    "notes": "Soft foam core street/AT hybrid for pothole-heavy routes.",
+    "tags": ["comfort", "commuter", "off-road"]
   },
   {
     "id": "wheels-at-110",
@@ -26,7 +45,10 @@
     "diameterMm": 110,
     "hardnessA": 74,
     "contactPatchMm": 64,
+    "widthMm": 65,
     "wheelType": "all-terrain",
-    "notes": "Tall profile for mixed pavement and packed dirt."
+    "lipShape": "rounded",
+    "notes": "Tall profile for mixed pavement and packed dirt.",
+    "tags": ["off-road", "adventure"]
   }
 ]

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,13 +15,17 @@ export interface BoardComponent {
   category: ComponentCategory;
   description?: string;
   notes?: string;
+  tags?: string[];
 }
 
 export interface Deck extends BoardComponent {
   category: "deck";
   lengthCm: number;
-  flex: "stiff" | "medium" | "flexy";
-  mountStyle: "top-mount" | "drop-through";
+  wheelbaseCm?: number;
+  widthCm?: number;
+  flex?: "stiff" | "medium" | "flexy";
+  mountStyle: "top-mount" | "drop-through" | "drop-deck";
+  deckStyle?: "commuter" | "freeride" | "downhill" | "carver" | "cruiser";
 }
 
 export interface Trucks extends BoardComponent {
@@ -29,28 +33,39 @@ export interface Trucks extends BoardComponent {
   widthMm: number;
   truckType: "RKP" | "PKP";
   mountCompatibility: Array<"top-mount" | "drop-through">;
+  baseplateAngleDeg?: number;
+  axleDiameterMm?: number;
 }
 
 export interface Wheels extends BoardComponent {
   category: "wheels";
   diameterMm: number;
   hardnessA: number;
-  contactPatchMm: number;
+  contactPatchMm?: number;
+  widthMm?: number;
   wheelType: "street" | "all-terrain";
+  lipShape?: "square" | "rounded";
 }
 
 export interface Battery extends BoardComponent {
   category: "battery";
   capacityWh: number;
   voltageClass: VoltageClass;
-  continuousDischargeA: number;
+  continuousDischargeA?: number;
+  configuration?: string;
+  cellFormat?: string;
+  smartBms?: boolean;
 }
 
 export interface Esc extends BoardComponent {
   category: "esc";
   supportedVoltageClasses: VoltageClass[];
-  maxContinuousCurrentA: number;
+  maxContinuousCurrentA?: number;
   motorCount: "single" | "dual";
+  connectors?: string[];
+  hasBluetooth?: boolean;
+  hasTelemetry?: boolean;
+  waterproofRating?: string;
 }
 
 export interface DriveKit extends BoardComponent {
@@ -59,12 +74,19 @@ export interface DriveKit extends BoardComponent {
   supportedVoltageClasses: VoltageClass[];
   maxPowerW: number;
   profile: "high_torque" | "balanced" | "high_speed";
+  driveType?: "belt" | "gear" | "hub" | "direct";
+  ratio?: string;
+  wheelCompatibility?: string;
 }
 
 export interface Remote extends BoardComponent {
   category: "remote";
   frequency: string;
   compatibleEscFamilies?: string[];
+  triggerStyle?: "trigger" | "thumbwheel";
+  hasTelemetry?: boolean;
+  ridingModes?: number;
+  waterproofRating?: string;
 }
 
 export interface BuildState {


### PR DESCRIPTION
## Summary
- expand part schemas with esk8-relevant optional specs and tagging support
- populate catalogs with realistic longboard components and richer metadata
- surface key specs and shared intent cues across the selector, overview, and BOM

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c3f59e34832e814d34b9b7f4c38a)