### PR TITLE
Replace placeholder catalog with curated esk8 parts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,64 +21,64 @@ function capitalize(word?: string) {
   return word.charAt(0).toUpperCase() + word.slice(1);
 }
 
+function formatDisplayName(part: BuildPart) {
+  return `${part.brand} ${part.name}`;
+}
+
 function formatDeckSummary(deck: Deck) {
-  const style = deck.deckStyle ? capitalize(deck.deckStyle) : capitalize(deck.mountStyle);
-  const flexLabel = deck.flex ? `${deck.flex} flex` : undefined;
-  return [
-    `${deck.lengthCm}cm`,
-    style,
-    flexLabel,
-    deck.wheelbaseCm ? `${deck.wheelbaseCm}cm wheelbase` : undefined,
-  ]
+  const flexLabel = deck.flex ? `${capitalize(deck.flex)} flex` : undefined;
+  return [`${deck.lengthCm}cm`, capitalize(deck.style), flexLabel]
     .filter(Boolean)
     .join(" · ");
 }
 
 function formatTrucksSummary(trucks: Trucks) {
-  const angle = trucks.baseplateAngleDeg ? `${trucks.baseplateAngleDeg}°` : undefined;
-  return [`${trucks.widthMm}mm`, trucks.truckType, angle].filter(Boolean).join(" · ");
+  return [`${trucks.hangerWidthMm}mm hanger`, `${trucks.baseplateAngleDeg}°`, trucks.type]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function formatWheelsSummary(wheels: Wheels) {
-  const shape = wheels.lipShape ? `${wheels.lipShape} lip` : undefined;
-  return [`${wheels.diameterMm}mm`, `${wheels.hardnessA}A`, wheels.wheelType, shape]
+  return [`${wheels.diameterMm}mm`, `${wheels.durometerA}A`, capitalize(wheels.type)]
     .filter(Boolean)
     .join(" · ");
 }
 
 function formatBatterySummary(battery: Battery) {
-  return [
-    `${battery.capacityWh}Wh`,
-    battery.voltageClass,
-    battery.configuration,
-    battery.cellFormat,
-  ]
+  return [`${battery.cells}`, `${battery.capacityWh}Wh`, battery.voltageClass]
     .filter(Boolean)
     .join(" · ");
 }
 
 function formatEscSummary(esc: Esc) {
   const motorLabel = esc.motorCount === "dual" ? "Dual" : "Single";
-  const telemetryLabel = esc.hasTelemetry ? "Telemetry" : undefined;
   return [
     `Supports ${esc.supportedVoltageClasses.join("/")}`,
     `${motorLabel} motor`,
-    telemetryLabel,
+    `${esc.maxContinuousCurrentA}A max`,
+    esc.hasTelemetry ? "Telemetry" : undefined,
   ]
     .filter(Boolean)
     .join(" · ");
 }
 
 function formatDriveKitSummary(driveKit: DriveKit) {
-  const type = driveKit.driveType ? capitalize(driveKit.driveType) : "Belt";
-  const profile = driveKit.profile.replace("_", " ");
-  return [type, `${driveKit.kv}KV`, driveKit.ratio, profile].filter(Boolean).join(" · ");
+  return [
+    `${capitalize(driveKit.driveType)} drive`,
+    `${driveKit.kv}KV`,
+    `${capitalize(driveKit.characterTag)}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function formatRemoteSummary(remote: Remote) {
-  const control = remote.triggerStyle ? `${capitalize(remote.triggerStyle)} control` : undefined;
-  const telemetry = remote.hasTelemetry ? "Telemetry" : undefined;
-  return [control, remote.frequency, telemetry].filter(Boolean).join(" · ");
+  return [
+    `ESC: ${remote.escFamilies.join("/")}`,
+    remote.hasTelemetry ? "Telemetry" : "No telemetry",
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function getKeySpec(item?: BuildPart) {
@@ -310,10 +310,14 @@ export default function HomePage() {
               <SectionHeader
                 title="Deck"
                 subtitle="Choose your platform"
-                selectedLabel={build.selectedDeck?.name}
+                selectedLabel={
+                  build.selectedDeck ? formatDisplayName(build.selectedDeck) : undefined
+                }
               />
               {build.selectedDeck ? (
-                <div className="mt-2 text-[11px] text-emerald-200">Selected: {build.selectedDeck.name}</div>
+                <div className="mt-2 text-[11px] text-emerald-200">
+                  Selected: {formatDisplayName(build.selectedDeck)}
+                </div>
               ) : (
                 <div className="mt-2 text-[11px] text-slate-400">Not selected yet</div>
               )}
@@ -329,13 +333,13 @@ export default function HomePage() {
                 {catalog.decks.map((deck) => (
                   <SelectorCard
                     key={deck.id}
-                    title={deck.name}
+                    title={formatDisplayName(deck)}
                     description={deck.notes}
                     meta={
                       [
                         `${deck.lengthCm}cm`,
-                        deck.deckStyle ? capitalize(deck.deckStyle) : deck.mountStyle,
-                        deck.flex ? `${deck.flex} flex` : undefined,
+                        capitalize(deck.style),
+                        deck.flex ? `${capitalize(deck.flex)} flex` : undefined,
                       ].filter(Boolean) as string[]
                     }
                     onSelect={() => handleDeckSelect(deck)}
@@ -350,11 +354,13 @@ export default function HomePage() {
               <SectionHeader
                 title="Trucks"
                 subtitle="Dial in your turning style"
-                selectedLabel={build.selectedTrucks?.name}
+                selectedLabel={
+                  build.selectedTrucks ? formatDisplayName(build.selectedTrucks) : undefined
+                }
               />
               {build.selectedTrucks ? (
                 <div className="mt-2 text-[11px] text-emerald-200">
-                  Selected: {build.selectedTrucks.name}
+                  Selected: {formatDisplayName(build.selectedTrucks)}
                 </div>
               ) : (
                 <div className="mt-2 text-[11px] text-slate-400">Not selected yet</div>
@@ -371,13 +377,13 @@ export default function HomePage() {
                 {catalog.trucks.map((truck) => (
                   <SelectorCard
                     key={truck.id}
-                    title={truck.name}
+                    title={formatDisplayName(truck)}
                     description={truck.notes}
                     meta={
                       [
-                        `${truck.widthMm}mm`,
-                        `${truck.truckType}`,
-                        truck.baseplateAngleDeg ? `${truck.baseplateAngleDeg}° baseplate` : undefined,
+                        `${truck.hangerWidthMm}mm hanger`,
+                        `${truck.baseplateAngleDeg}° baseplate`,
+                        `${truck.type}`,
                       ].filter(Boolean) as string[]
                     }
                     onSelect={() => handleTrucksSelect(truck)}
@@ -392,11 +398,13 @@ export default function HomePage() {
               <SectionHeader
                 title="Wheels"
                 subtitle="Set your ride feel"
-                selectedLabel={build.selectedWheels?.name}
+                selectedLabel={
+                  build.selectedWheels ? formatDisplayName(build.selectedWheels) : undefined
+                }
               />
               {build.selectedWheels ? (
                 <div className="mt-2 text-[11px] text-emerald-200">
-                  Selected: {build.selectedWheels.name}
+                  Selected: {formatDisplayName(build.selectedWheels)}
                 </div>
               ) : (
                 <div className="mt-2 text-[11px] text-slate-400">Not selected yet</div>
@@ -413,15 +421,13 @@ export default function HomePage() {
                 {catalog.wheels.map((wheel) => (
                   <SelectorCard
                     key={wheel.id}
-                    title={wheel.name}
+                    title={formatDisplayName(wheel)}
                     description={wheel.notes}
-                    meta={
-                      [
-                        `${wheel.diameterMm}mm`,
-                        `${wheel.hardnessA}A`,
-                        wheel.wheelType === "all-terrain" ? "All-terrain" : "Street",
-                      ]
-                    }
+                    meta={[
+                      `${wheel.diameterMm}mm`,
+                      `${wheel.durometerA}A`,
+                      wheel.type === "all-terrain" ? "All-terrain" : "Street",
+                    ]}
                     onSelect={() => handleWheelsSelect(wheel)}
                     isSelected={build.selectedWheels?.id === wheel.id}
                     badge="Wheels"
@@ -445,13 +451,13 @@ export default function HomePage() {
                 {catalog.batteries.map((battery) => (
                   <SelectorCard
                     key={battery.id}
-                    title={battery.name}
+                    title={formatDisplayName(battery)}
                     description={battery.notes}
                     meta={
                       [
+                        `${battery.cells}`,
                         `${battery.capacityWh}Wh`,
                         `${battery.voltageClass}`,
-                        battery.configuration ?? `${battery.continuousDischargeA ?? ""}A`,
                       ].filter(Boolean) as string[]
                     }
                     onSelect={() => handleBatterySelect(battery)}
@@ -473,13 +479,14 @@ export default function HomePage() {
                 {catalog.escs.map((esc) => (
                   <SelectorCard
                     key={esc.id}
-                    title={esc.name}
+                    title={formatDisplayName(esc)}
                     description={esc.notes}
                     meta={
                       [
                         `Supports ${esc.supportedVoltageClasses.join("/")}`,
+                        `${esc.maxContinuousCurrentA}A max`,
                         `${esc.motorCount === "dual" ? "Dual" : "Single"} motor`,
-                        esc.hasBluetooth ? "Bluetooth" : esc.connectors?.[0],
+                        esc.hasTelemetry ? "Telemetry" : undefined,
                       ].filter(Boolean) as string[]
                     }
                     onSelect={() => handleEscSelect(esc)}
@@ -501,14 +508,14 @@ export default function HomePage() {
                 {catalog.driveKits.map((driveKit) => (
                   <SelectorCard
                     key={driveKit.id}
-                    title={driveKit.name}
+                    title={formatDisplayName(driveKit)}
                     description={driveKit.notes}
                     meta={
                       [
-                        `${capitalize(driveKit.driveType || "belt")} drive`,
+                        `${capitalize(driveKit.driveType)} drive`,
                         `${driveKit.kv}KV`,
-                        driveKit.ratio || driveKit.profile.replace("_", " "),
-                      ]
+                        `${capitalize(driveKit.characterTag)}`,
+                      ] as string[]
                     }
                     onSelect={() => handleDriveKitSelect(driveKit)}
                     isSelected={build.selectedDriveKit?.id === driveKit.id}
@@ -530,11 +537,13 @@ export default function HomePage() {
               <SectionHeader
                 title="Remote"
                 subtitle="Control your ride"
-                selectedLabel={build.selectedRemote?.name}
+                selectedLabel={
+                  build.selectedRemote ? formatDisplayName(build.selectedRemote) : undefined
+                }
               />
               {build.selectedRemote ? (
                 <div className="mt-2 text-[11px] text-emerald-200">
-                  Selected: {build.selectedRemote.name}
+                  Selected: {formatDisplayName(build.selectedRemote)}
                 </div>
               ) : (
                 <div className="mt-2 text-[11px] text-slate-400">Not selected yet</div>
@@ -551,15 +560,12 @@ export default function HomePage() {
                 {catalog.remotes.map((remote) => (
                   <SelectorCard
                     key={remote.id}
-                    title={remote.name}
+                    title={formatDisplayName(remote)}
                     description={remote.notes}
                     meta={
                       [
-                        remote.triggerStyle
-                          ? `${capitalize(remote.triggerStyle)} control`
-                          : "Trigger control",
-                        remote.frequency,
-                        remote.hasTelemetry ? "Telemetry" : remote.compatibleEscFamilies?.[0],
+                        `ESC: ${remote.escFamilies.join("/")}`,
+                        remote.hasTelemetry ? "Telemetry" : "No telemetry",
                       ].filter(Boolean) as string[]
                     }
                     onSelect={() => handleRemoteSelect(remote)}
@@ -587,14 +593,14 @@ export default function HomePage() {
             <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-200">
               <div className="space-y-1">
                 <p className="text-xs uppercase text-slate-400">Deck</p>
-                <p>{build.selectedDeck?.name || "Not selected"}</p>
+                <p>{build.selectedDeck ? formatDisplayName(build.selectedDeck) : "Not selected"}</p>
                 <p className="text-[11px] text-slate-400">
                   {build.selectedDeck ? formatDeckSummary(build.selectedDeck) : "Select a deck to view specs"}
                 </p>
               </div>
               <div className="space-y-1">
                 <p className="text-xs uppercase text-slate-400">Trucks</p>
-                <p>{build.selectedTrucks?.name || "Not selected"}</p>
+                <p>{build.selectedTrucks ? formatDisplayName(build.selectedTrucks) : "Not selected"}</p>
                 <p className="text-[11px] text-slate-400">
                   {build.selectedTrucks
                     ? formatTrucksSummary(build.selectedTrucks)
@@ -603,7 +609,7 @@ export default function HomePage() {
               </div>
               <div className="space-y-1">
                 <p className="text-xs uppercase text-slate-400">Wheels</p>
-                <p>{build.selectedWheels?.name || "Not selected"}</p>
+                <p>{build.selectedWheels ? formatDisplayName(build.selectedWheels) : "Not selected"}</p>
                 <p className="text-[11px] text-slate-400">
                   {build.selectedWheels
                     ? formatWheelsSummary(build.selectedWheels)
@@ -612,7 +618,9 @@ export default function HomePage() {
               </div>
               <div className="space-y-1">
                 <p className="text-xs uppercase text-slate-400">Battery</p>
-                <p>{build.selectedBattery?.name || "Not selected"}</p>
+                <p>
+                  {build.selectedBattery ? formatDisplayName(build.selectedBattery) : "Not selected"}
+                </p>
                 <p className="text-[11px] text-slate-400">
                   {build.selectedBattery
                     ? formatBatterySummary(build.selectedBattery)
@@ -621,14 +629,16 @@ export default function HomePage() {
               </div>
               <div className="space-y-1">
                 <p className="text-xs uppercase text-slate-400">ESC</p>
-                <p>{build.selectedEsc?.name || "Not selected"}</p>
+                <p>{build.selectedEsc ? formatDisplayName(build.selectedEsc) : "Not selected"}</p>
                 <p className="text-[11px] text-slate-400">
                   {build.selectedEsc ? formatEscSummary(build.selectedEsc) : "Add an ESC to check voltage support"}
                 </p>
               </div>
               <div className="space-y-1">
                 <p className="text-xs uppercase text-slate-400">Drive Kit</p>
-                <p>{build.selectedDriveKit?.name || "Not selected"}</p>
+                <p>
+                  {build.selectedDriveKit ? formatDisplayName(build.selectedDriveKit) : "Not selected"}
+                </p>
                 <p className="text-[11px] text-slate-400">
                   {build.selectedDriveKit
                     ? formatDriveKitSummary(build.selectedDriveKit)
@@ -637,7 +647,7 @@ export default function HomePage() {
               </div>
               <div className="space-y-1">
                 <p className="text-xs uppercase text-slate-400">Remote</p>
-                <p>{build.selectedRemote?.name || "Not selected"}</p>
+                <p>{build.selectedRemote ? formatDisplayName(build.selectedRemote) : "Not selected"}</p>
                 <p className="text-[11px] text-slate-400">
                   {build.selectedRemote ? formatRemoteSummary(build.selectedRemote) : "Choose a remote to see controls"}
                 </p>
@@ -699,11 +709,13 @@ export default function HomePage() {
                 >
                   <div>
                     <p className="text-[11px] uppercase text-slate-400">{label}</p>
-                    <p className="text-sm font-semibold text-white">{item?.name || "Not selected"}</p>
+                    <p className="text-sm font-semibold text-white">
+                      {item ? formatDisplayName(item) : "Not selected"}
+                    </p>
                     {item?.notes ? <p className="text-[11px] text-slate-400 mt-1">{item.notes}</p> : null}
                   </div>
                   <div className="text-right text-[11px] text-slate-300 min-w-[120px]">
-                    {item ? specs(item) : ""}
+                    {item ? specs(item) : "Choose a part"}
                   </div>
                 </div>
               ))}

--- a/data/batteries.json
+++ b/data/batteries.json
@@ -1,54 +1,42 @@
 [
   {
-    "id": "battery-10s-400",
-    "name": "10S 400Wh Commuter Pack",
+    "id": "battery-evolve-gtr-10s4p",
+    "brand": "Evolve",
+    "name": "GTR 10S4P 18650",
     "category": "battery",
-    "capacityWh": 400,
+    "cells": "10S4P",
     "voltageClass": "10S",
-    "continuousDischargeA": 60,
-    "configuration": "10S3P 21700",
-    "cellFormat": "21700",
-    "smartBms": true,
-    "notes": "Balanced range for daily riding with built-in BMS telemetry.",
-    "tags": ["commuter", "beginner"]
+    "capacityWh": 504,
+    "notes": "Samsung 35E-based pack used on Evolve GTR with integrated BMS."
   },
   {
-    "id": "battery-12s-540",
-    "name": "12S 540Wh Performance Pack",
+    "id": "battery-meepo-ercell-10s2p",
+    "brand": "Meepo",
+    "name": "Extended Range 10S2P",
     "category": "battery",
-    "capacityWh": 540,
+    "cells": "10S2P",
+    "voltageClass": "10S",
+    "capacityWh": 288,
+    "notes": "Compact ER pack often paired with Hobbywing ESCs for commuter builds."
+  },
+  {
+    "id": "battery-hurricane-12s4p-p42a",
+    "brand": "Meepo",
+    "name": "Hurricane 12S4P P42A",
+    "category": "battery",
+    "cells": "12S4P",
     "voltageClass": "12S",
-    "continuousDischargeA": 90,
-    "configuration": "12S3P 21700",
-    "cellFormat": "21700",
-    "smartBms": true,
-    "notes": "High-voltage pack for strong acceleration and braking headroom.",
-    "tags": ["speed", "performance"]
+    "capacityWh": 725,
+    "notes": "High-discharge 21700 pack using Molicel P42A cells for powerful setups."
   },
   {
-    "id": "battery-8s-320",
-    "name": "8S 320Wh Urban Pack",
+    "id": "battery-backfire-zealot-s-12s2p",
+    "brand": "Backfire",
+    "name": "Zealot S 12S2P",
     "category": "battery",
-    "capacityWh": 320,
-    "voltageClass": "8S",
-    "continuousDischargeA": 50,
-    "configuration": "8S2P 18650",
-    "cellFormat": "18650",
-    "smartBms": false,
-    "notes": "Lightweight pack for compact travel boards.",
-    "tags": ["commuter", "budget", "travel"]
-  },
-  {
-    "id": "battery-10s-450",
-    "name": "10S 450Wh Trail Pack",
-    "category": "battery",
-    "capacityWh": 450,
-    "voltageClass": "10S",
-    "continuousDischargeA": 70,
-    "configuration": "10S3P 18650",
-    "cellFormat": "18650",
-    "smartBms": false,
-    "notes": "Ruggedized enclosure for mixed-surface commuting.",
-    "tags": ["off-road", "adventure"]
+    "cells": "12S2P",
+    "voltageClass": "12S",
+    "capacityWh": 346,
+    "notes": "Lightweight 21700 pack balanced for range and punch on street wheels."
   }
 ]

--- a/data/decks.json
+++ b/data/decks.json
@@ -1,54 +1,42 @@
 [
   {
-    "id": "deck-commuter-38",
-    "name": "38\" Commuter Top-Mount",
+    "id": "deck-loaded-vanguard-flex2",
+    "brand": "Loaded Boards",
+    "name": "Vanguard Flex 2",
     "category": "deck",
-    "lengthCm": 97,
-    "wheelbaseCm": 70,
-    "widthCm": 23.5,
-    "flex": "medium",
-    "mountStyle": "top-mount",
-    "deckStyle": "commuter",
-    "notes": "Stable carving deck with mellow concave and foot-stop friendly nose.",
-    "tags": ["commuter", "beginner", "carve"]
-  },
-  {
-    "id": "deck-drop-40",
-    "name": "40\" Drop-Through Cruiser",
-    "category": "deck",
-    "lengthCm": 102,
-    "wheelbaseCm": 75,
-    "widthCm": 24,
+    "lengthCm": 96.5,
+    "style": "carver",
     "flex": "flexy",
-    "mountStyle": "drop-through",
-    "deckStyle": "cruiser",
-    "notes": "Lower ride height for push-friendly commuting and smooth carving.",
-    "tags": ["commuter", "comfort", "beginner"]
+    "notes": "Bamboo and fiberglass drop-through with lively flex for carving and commuting."
   },
   {
-    "id": "deck-downhill-37",
-    "name": "37\" Downhill Stiff",
+    "id": "deck-landyachtz-evo-40",
+    "brand": "Landyachtz",
+    "name": "Evo 40",
     "category": "deck",
-    "lengthCm": 94,
-    "wheelbaseCm": 68,
-    "widthCm": 23,
+    "lengthCm": 101.6,
+    "style": "downhill",
     "flex": "stiff",
-    "mountStyle": "top-mount",
-    "deckStyle": "downhill",
-    "notes": "Locked-in stance with micro-drop pockets for high-speed stability.",
-    "tags": ["speed", "downhill"]
+    "notes": "Micro-drop speedboard known for stability at high speeds and loaded builds."
   },
   {
-    "id": "deck-dropdeck-39",
-    "name": "39\" Drop-Deck Carver",
+    "id": "deck-evolve-bamboo-gtr",
+    "brand": "Evolve",
+    "name": "Bamboo GTR Deck",
     "category": "deck",
-    "lengthCm": 99,
-    "wheelbaseCm": 72,
-    "widthCm": 23.5,
+    "lengthCm": 96,
+    "style": "commuter",
     "flex": "medium",
-    "mountStyle": "drop-deck",
-    "deckStyle": "carver",
-    "notes": "Sunken platform with rocker for locked-in commuting and carving.",
-    "tags": ["commuter", "comfort", "carve"]
+    "notes": "Classic bamboo flex deck with comfortable concave for all-day cruising."
+  },
+  {
+    "id": "deck-rayne-anthem-38",
+    "brand": "Rayne",
+    "name": "Anthem 38",
+    "category": "deck",
+    "lengthCm": 96.5,
+    "style": "freeride",
+    "flex": "stiff",
+    "notes": "Vert-lam construction with mild rocker and pockets for a locked-in electric setup."
   }
 ]

--- a/data/driveKits.json
+++ b/data/driveKits.json
@@ -1,44 +1,46 @@
 [
   {
-    "id": "drivekit-ht-170",
-    "name": "170KV Torque Belt Drive",
+    "id": "drive-torqueboards-6380-dual-belt",
+    "brand": "TorqueBoards",
+    "name": "Dual 6380 Belt Kit",
     "category": "drive_kit",
-    "kv": 170,
-    "supportedVoltageClasses": ["8S", "10S"],
-    "maxPowerW": 2800,
-    "profile": "high_torque",
     "driveType": "belt",
-    "ratio": "15/36",
-    "wheelCompatibility": "90-110mm street",
-    "notes": "Geared for hill climbing and heavier riders.",
-    "tags": ["commuter", "hill", "cargo"]
+    "supportedVoltageClasses": ["10S", "12S"],
+    "kv": 170,
+    "characterTag": "torque",
+    "notes": "Dual 6380 motors with 15/36 gearing for punchy hill performance."
   },
   {
-    "id": "drivekit-balanced-190",
-    "name": "190KV Sealed Gear Drive",
+    "id": "drive-evolve-gtr-belt-5065",
+    "brand": "Evolve",
+    "name": "GTR 5065 Belt Drive",
     "category": "drive_kit",
-    "kv": 190,
+    "driveType": "belt",
+    "supportedVoltageClasses": ["10S"],
+    "kv": 150,
+    "characterTag": "balanced",
+    "notes": "Stock Evolve belt setup tuned around 32T/15T ratios for mixed terrain."
+  },
+  {
+    "id": "drive-onsra-direct-170kv",
+    "brand": "Onsra",
+    "name": "Direct Drive 170KV",
+    "category": "drive_kit",
+    "driveType": "direct",
     "supportedVoltageClasses": ["10S", "12S"],
-    "maxPowerW": 3200,
-    "profile": "balanced",
+    "kv": 170,
+    "characterTag": "speed",
+    "notes": "Low-maintenance direct drive with steel sleeves for urethane wheels."
+  },
+  {
+    "id": "drive-boundmotor-gear-150kv",
+    "brand": "BoundMotor",
+    "name": "Gear Drive 150KV",
+    "category": "drive_kit",
     "driveType": "gear",
-    "ratio": "2.4:1",
-    "wheelCompatibility": "97-110mm street/AT",
-    "notes": "Blend of acceleration and top speed with low maintenance.",
-    "tags": ["performance", "speed"]
-  },
-  {
-    "id": "drivekit-speed-200",
-    "name": "200KV Stealth Hub Set",
-    "category": "drive_kit",
-    "kv": 200,
     "supportedVoltageClasses": ["10S", "12S"],
-    "maxPowerW": 3000,
-    "profile": "high_speed",
-    "driveType": "hub",
-    "ratio": "direct",
-    "wheelCompatibility": "90-105mm street",
-    "notes": "Low-drag hub motors optimized for fast flats.",
-    "tags": ["speed", "stealth"]
+    "kv": 150,
+    "characterTag": "torque",
+    "notes": "Sealed gear drive with straight-cut reduction for off-road traction."
   }
 ]

--- a/data/escs.json
+++ b/data/escs.json
@@ -1,44 +1,35 @@
 [
   {
-    "id": "esc-dual-10s",
-    "name": "Dual Touring ESC (8S/10S)",
-    "category": "esc",
-    "supportedVoltageClasses": ["8S", "10S"],
-    "maxContinuousCurrentA": 60,
-    "motorCount": "dual",
-    "connectors": ["MR60", "sensor"],
-    "hasBluetooth": true,
-    "hasTelemetry": true,
-    "waterproofRating": "IP65",
-    "notes": "Great for 2WD commuter setups with app tuning.",
-    "tags": ["commuter", "beginner"]
-  },
-  {
-    "id": "esc-performance-12s",
-    "name": "Performance ESC 12S",
+    "id": "esc-flipsky-dual-6.6-plus",
+    "brand": "Flipsky",
+    "name": "FSESC 6.6 Dual Plus",
     "category": "esc",
     "supportedVoltageClasses": ["10S", "12S"],
-    "maxContinuousCurrentA": 80,
+    "maxContinuousCurrentA": 60,
     "motorCount": "dual",
-    "connectors": ["QS8", "sensor"],
-    "hasBluetooth": true,
     "hasTelemetry": true,
-    "waterproofRating": "IP67",
-    "notes": "Designed for high-voltage builds with active cooling path.",
-    "tags": ["speed", "performance"]
+    "notes": "Dual VESC-based controller with Bluetooth and CAN for high-power builds."
   },
   {
-    "id": "esc-urban-8s",
-    "name": "Compact ESC 6S/8S",
+    "id": "esc-makerx-dv6",
+    "brand": "MakerX",
+    "name": "DV6",
     "category": "esc",
-    "supportedVoltageClasses": ["6S", "8S"],
-    "maxContinuousCurrentA": 50,
-    "motorCount": "single",
-    "connectors": ["XT60"],
-    "hasBluetooth": false,
+    "supportedVoltageClasses": ["10S", "12S"],
+    "maxContinuousCurrentA": 60,
+    "motorCount": "dual",
+    "hasTelemetry": true,
+    "notes": "Compact dual VESC with aluminum shell and strong braking."
+  },
+  {
+    "id": "esc-hobbywing-v4-dual",
+    "brand": "Hobbywing",
+    "name": "V4 Dual ESC",
+    "category": "esc",
+    "supportedVoltageClasses": ["10S"],
+    "maxContinuousCurrentA": 40,
+    "motorCount": "dual",
     "hasTelemetry": false,
-    "waterproofRating": "IP54",
-    "notes": "Efficient controller for lightweight boards and travel builds.",
-    "tags": ["commuter", "budget", "travel"]
+    "notes": "Smooth, quiet control stack widely shipped on commuter prebuilts."
   }
 ]

--- a/data/remotes.json
+++ b/data/remotes.json
@@ -1,41 +1,20 @@
 [
   {
-    "id": "remote-simple",
-    "name": "Simple Trigger Remote",
+    "id": "remote-hoyt-puck",
+    "brand": "Hoyt St",
+    "name": "Puck",
     "category": "remote",
-    "frequency": "2.4GHz",
-    "compatibleEscFamilies": ["VESC-style", "Hobby dual"],
-    "triggerStyle": "trigger",
+    "escFamilies": ["VESC"],
     "hasTelemetry": false,
-    "ridingModes": 2,
-    "waterproofRating": "IP54",
-    "notes": "Basic throttle with cruise toggle.",
-    "tags": ["beginner", "budget"]
+    "notes": "Trigger-style remote with latching power and swappable shells."
   },
   {
-    "id": "remote-telemetry",
-    "name": "Telemetry GT Remote",
+    "id": "remote-flipsky-vx3",
+    "brand": "Flipsky",
+    "name": "VX3",
     "category": "remote",
-    "frequency": "2.4GHz",
-    "compatibleEscFamilies": ["VESC-style"],
-    "triggerStyle": "trigger",
+    "escFamilies": ["VESC"],
     "hasTelemetry": true,
-    "ridingModes": 4,
-    "waterproofRating": "IP55",
-    "notes": "Displays speed and battery status with haptic alerts.",
-    "tags": ["performance", "speed"]
-  },
-  {
-    "id": "remote-compact",
-    "name": "Compact Thumbwheel",
-    "category": "remote",
-    "frequency": "2.4GHz",
-    "compatibleEscFamilies": ["Light ESC"],
-    "triggerStyle": "thumbwheel",
-    "hasTelemetry": false,
-    "ridingModes": 2,
-    "waterproofRating": "IPX4",
-    "notes": "Pocketable remote for travel boards.",
-    "tags": ["travel", "commuter"]
+    "notes": "2.4GHz remote with screen telemetry and cruise control support."
   }
 ]

--- a/data/trucks.json
+++ b/data/trucks.json
@@ -1,38 +1,32 @@
 [
   {
-    "id": "trucks-rkp-180",
-    "name": "180mm 50° RKP Carve",
+    "id": "trucks-paris-v3-180",
+    "brand": "Paris Truck Co.",
+    "name": "V3 180mm 50°",
     "category": "trucks",
-    "widthMm": 180,
-    "truckType": "RKP",
-    "mountCompatibility": ["top-mount", "drop-through"],
+    "hangerWidthMm": 180,
     "baseplateAngleDeg": 50,
-    "axleDiameterMm": 8,
-    "notes": "Responsive turning with stable center and tall bushings.",
-    "tags": ["carve", "commuter"]
+    "type": "RKP",
+    "notes": "Forged 356 aluminum RKP truck popular for carving electric setups."
   },
   {
-    "id": "trucks-pkp-170",
-    "name": "170mm 44° PKP Street",
+    "id": "trucks-caliber-iii-184",
+    "brand": "Caliber",
+    "name": "III 184mm 50°",
     "category": "trucks",
-    "widthMm": 170,
-    "truckType": "PKP",
-    "mountCompatibility": ["top-mount"],
-    "baseplateAngleDeg": 44,
-    "axleDiameterMm": 8,
-    "notes": "Low ride height and quick lean for urban riding.",
-    "tags": ["commuter", "budget"]
+    "hangerWidthMm": 184,
+    "baseplateAngleDeg": 50,
+    "type": "RKP",
+    "notes": "Tall bushing seat with rigid hanger—common on powerful DIY builds."
   },
   {
-    "id": "trucks-rkp-184",
-    "name": "184mm 45° Precision RKP",
+    "id": "trucks-bear-grizzly-gen6",
+    "brand": "Bear",
+    "name": "Grizzly Gen 6 181mm 50°",
     "category": "trucks",
-    "widthMm": 184,
-    "truckType": "RKP",
-    "mountCompatibility": ["top-mount"],
-    "baseplateAngleDeg": 45,
-    "axleDiameterMm": 8,
-    "notes": "CNC hangers with tight tolerances for speed-focused builds.",
-    "tags": ["speed", "downhill"]
+    "hangerWidthMm": 181,
+    "baseplateAngleDeg": 50,
+    "type": "RKP",
+    "notes": "Responsive downhill-inspired RKP truck with beefy axles for electric use."
   }
 ]

--- a/data/wheels.json
+++ b/data/wheels.json
@@ -1,54 +1,42 @@
 [
   {
-    "id": "wheels-street-90",
-    "name": "90mm Street Grip",
+    "id": "wheel-orangatang-caguama-85-83a",
+    "brand": "Orangatang",
+    "name": "Caguama 85mm 83a",
     "category": "wheels",
-    "diameterMm": 90,
-    "hardnessA": 78,
-    "contactPatchMm": 56,
-    "widthMm": 52,
-    "wheelType": "street",
-    "lipShape": "square",
-    "notes": "Grippy urethane for smooth pavement.",
-    "tags": ["commuter", "carve"]
+    "diameterMm": 85,
+    "durometerA": 83,
+    "type": "street",
+    "notes": "Happy Thane formula with wide contact patch for plush commuting."
   },
   {
-    "id": "wheels-street-97",
-    "name": "97mm Comfort Roll",
+    "id": "wheel-abec11-superfly-107-74a",
+    "brand": "ABEC 11",
+    "name": "SuperFly 107mm 74a",
     "category": "wheels",
-    "diameterMm": 97,
-    "hardnessA": 76,
-    "contactPatchMm": 60,
-    "widthMm": 55,
-    "wheelType": "street",
-    "lipShape": "rounded",
-    "notes": "Extra damping for rougher bike paths.",
-    "tags": ["commuter", "comfort"]
+    "diameterMm": 107,
+    "durometerA": 74,
+    "type": "street",
+    "notes": "Giant urethane wheel that smooths rough pavement and boosts top speed."
   },
   {
-    "id": "wheels-at-105",
-    "name": "105mm Cloud Hybrid",
+    "id": "wheel-cloudwheel-discovery-105-78a",
+    "brand": "IWONDER",
+    "name": "Cloudwheel Discovery 105mm 78a",
     "category": "wheels",
     "diameterMm": 105,
-    "hardnessA": 78,
-    "contactPatchMm": 62,
-    "widthMm": 60,
-    "wheelType": "all-terrain",
-    "lipShape": "rounded",
-    "notes": "Soft foam core street/AT hybrid for pothole-heavy routes.",
-    "tags": ["comfort", "commuter", "off-road"]
+    "durometerA": 78,
+    "type": "all-terrain",
+    "notes": "Vapor-core airless design that softens cracks without full pneumatics."
   },
   {
-    "id": "wheels-at-110",
-    "name": "110mm All-Terrain",
+    "id": "wheel-evolve-gt-97-76a",
+    "brand": "Evolve",
+    "name": "GT 97mm 76a",
     "category": "wheels",
-    "diameterMm": 110,
-    "hardnessA": 74,
-    "contactPatchMm": 64,
-    "widthMm": 65,
-    "wheelType": "all-terrain",
-    "lipShape": "rounded",
-    "notes": "Tall profile for mixed pavement and packed dirt.",
-    "tags": ["off-road", "adventure"]
+    "diameterMm": 97,
+    "durometerA": 76,
+    "type": "street",
+    "notes": "Stone-ground urethane tuned for Evolve belt drive boards and long ranges."
   }
 ]

--- a/types/index.ts
+++ b/types/index.ts
@@ -11,9 +11,9 @@ export type ComponentCategory =
 
 export interface BoardComponent {
   id: string;
+  brand: string;
   name: string;
   category: ComponentCategory;
-  description?: string;
   notes?: string;
   tags?: string[];
 }
@@ -21,72 +21,51 @@ export interface BoardComponent {
 export interface Deck extends BoardComponent {
   category: "deck";
   lengthCm: number;
-  wheelbaseCm?: number;
-  widthCm?: number;
+  style: "commuter" | "freeride" | "downhill" | "carver" | "cruiser";
   flex?: "stiff" | "medium" | "flexy";
-  mountStyle: "top-mount" | "drop-through" | "drop-deck";
-  deckStyle?: "commuter" | "freeride" | "downhill" | "carver" | "cruiser";
 }
 
 export interface Trucks extends BoardComponent {
   category: "trucks";
-  widthMm: number;
-  truckType: "RKP" | "PKP";
-  mountCompatibility: Array<"top-mount" | "drop-through">;
-  baseplateAngleDeg?: number;
-  axleDiameterMm?: number;
+  hangerWidthMm: number;
+  baseplateAngleDeg: number;
+  type: "RKP" | "PKP" | "DKP";
 }
 
 export interface Wheels extends BoardComponent {
   category: "wheels";
   diameterMm: number;
-  hardnessA: number;
-  contactPatchMm?: number;
-  widthMm?: number;
-  wheelType: "street" | "all-terrain";
-  lipShape?: "square" | "rounded";
+  durometerA: number;
+  type: "street" | "all-terrain";
 }
 
 export interface Battery extends BoardComponent {
   category: "battery";
   capacityWh: number;
   voltageClass: VoltageClass;
-  continuousDischargeA?: number;
-  configuration?: string;
-  cellFormat?: string;
-  smartBms?: boolean;
+  cells: string;
 }
 
 export interface Esc extends BoardComponent {
   category: "esc";
   supportedVoltageClasses: VoltageClass[];
-  maxContinuousCurrentA?: number;
+  maxContinuousCurrentA: number;
   motorCount: "single" | "dual";
-  connectors?: string[];
-  hasBluetooth?: boolean;
   hasTelemetry?: boolean;
-  waterproofRating?: string;
 }
 
 export interface DriveKit extends BoardComponent {
   category: "drive_kit";
   kv: number;
   supportedVoltageClasses: VoltageClass[];
-  maxPowerW: number;
-  profile: "high_torque" | "balanced" | "high_speed";
-  driveType?: "belt" | "gear" | "hub" | "direct";
-  ratio?: string;
-  wheelCompatibility?: string;
+  driveType: "belt" | "gear" | "hub" | "direct";
+  characterTag: "torque" | "balanced" | "speed";
 }
 
 export interface Remote extends BoardComponent {
   category: "remote";
-  frequency: string;
-  compatibleEscFamilies?: string[];
-  triggerStyle?: "trigger" | "thumbwheel";
-  hasTelemetry?: boolean;
-  ridingModes?: number;
-  waterproofRating?: string;
+  escFamilies: string[];
+  hasTelemetry: boolean;
 }
 
 export interface BuildState {


### PR DESCRIPTION
## Summary
- finalize component schemas with brand-forward fields and focused specs per category
- replace placeholder component data with a curated catalog of real esk8 parts across decks, trucks, wheels, batteries, ESCs, drive kits, and remotes
- update selectors, overview, and BOM displays to surface brand names and key specs for each chosen part

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69290adc5b2c832eb7b23d20108ac2a2)