### PR TITLE
Polish deck comparison and overview for v0.2

### DIFF
--- a/app/components/ComparisonTable.tsx
+++ b/app/components/ComparisonTable.tsx
@@ -8,6 +8,7 @@ export type ComparisonColumn<T> = {
   sortable?: boolean;
   getSortValue?: (item: T) => string | number | undefined;
   render: (item: T) => React.ReactNode;
+  align?: "left" | "center" | "right";
 };
 
 export type ComparisonTableProps<T extends { id: string }> = {
@@ -78,14 +79,16 @@ export function ComparisonTable<T extends { id: string }>({
   };
 
   return (
-    <div className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-950/70">
+    <div className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-950/70 shadow-lg shadow-emerald-900/10">
       <table className="min-w-full text-left text-sm">
-        <thead className="bg-slate-900/60 text-[11px] uppercase tracking-wide text-slate-400">
+        <thead className="sticky top-0 z-10 bg-slate-900/70 text-[11px] uppercase tracking-wide text-slate-400 backdrop-blur">
           <tr>
             {columns.map((col) => (
               <th
                 key={col.key}
-                className={`px-4 py-3 font-semibold ${col.sortable ? "cursor-pointer select-none" : ""}`}
+                className={`px-4 py-3 font-semibold ${
+                  col.sortable ? "cursor-pointer select-none transition hover:text-emerald-200" : ""
+                } ${col.align === "right" ? "text-right" : col.align === "center" ? "text-center" : "text-left"}`}
                 onClick={() => (col.sortable ? handleSort(col.key) : undefined)}
               >
                 <div className="flex items-center gap-1">
@@ -101,22 +104,36 @@ export function ComparisonTable<T extends { id: string }>({
           </tr>
         </thead>
         <tbody>
-          {sortedItems.map((item) => (
-            <tr
-              key={item.id}
-              className={`border-t border-slate-800 text-slate-200 ${
-                highlightedId === item.id
-                  ? "bg-emerald-500/5"
-                  : "hover:bg-slate-900/50"
-              }`}
-            >
-              {columns.map((col) => (
-                <td key={col.key} className="px-4 py-3">
-                  {col.render(item)}
-                </td>
-              ))}
-            </tr>
-          ))}
+          {sortedItems.map((item, index) => {
+            const isHighlighted = highlightedId === item.id;
+            const zebra = index % 2 === 0 ? "bg-slate-950/40" : "bg-slate-900/40";
+
+            return (
+              <tr
+                key={item.id}
+                className={`border-t border-slate-800 text-slate-200 transition ${zebra} ${
+                  isHighlighted
+                    ? "relative isolate bg-emerald-500/5 ring-1 ring-emerald-400/60"
+                    : "hover:bg-slate-900/70"
+                }`}
+              >
+                {columns.map((col) => (
+                  <td
+                    key={col.key}
+                    className={`px-4 py-3 align-middle ${
+                      col.align === "right"
+                        ? "text-right"
+                        : col.align === "center"
+                          ? "text-center"
+                          : "text-left"
+                    }`}
+                  >
+                    {col.render(item)}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/lib/catalog.ts
+++ b/lib/catalog.ts
@@ -1,13 +1,18 @@
 import batteries from "@/data/batteries.json";
-import decks from "@/data/decks.json";
+import deckData from "@/data/decks.json";
 import driveKits from "@/data/driveKits.json";
 import escs from "@/data/escs.json";
 import remotes from "@/data/remotes.json";
 import trucks from "@/data/trucks.json";
 import wheels from "@/data/wheels.json";
-import type { CatalogData } from "@/types";
+import type { CatalogData, Deck } from "@/types";
 
 export function getCatalog(): CatalogData {
+  const decks: Deck[] = deckData.map((deck) => ({
+    ...deck,
+    category: "deck",
+  }));
+
   return {
     decks,
     trucks,

--- a/types/index.ts
+++ b/types/index.ts
@@ -25,23 +25,27 @@ export interface BoardComponent {
   offers?: Offer[];
 }
 
-export type DeckStyle =
-  | "commuter"
-  | "freeride"
-  | "downhill"
-  | "carver"
-  | "cruiser"
-  | "top-mount"
-  | "drop-through"
-  | "drop-down";
+export type DeckStyle = string;
 
-export interface Deck extends BoardComponent {
+export interface Deck {
+  id: string;
+  brand: string;
+  name: string;
   category: "deck";
+  style: DeckStyle;
   lengthCm: number;
   widthCm?: number;
-  style: DeckStyle;
-  flex?: "stiff" | "medium" | "flexy";
-  flexRating?: number;
+  wheelbaseMinCm?: number;
+  wheelbaseMaxCm?: number;
+  flex?: number | string;
+  weightDeckOnlyLb?: number;
+  tags?: string[];
+  notes?: string;
+  vendorName: string;
+  productUrl: string;
+  priceCurrency: string;
+  priceValue: number;
+  lastVerifiedAt?: string;
 }
 
 export interface Trucks extends BoardComponent {


### PR DESCRIPTION
## Summary
- align Deck typing and catalog ingestion with the updated deck schema, including pricing and vendor fields
- refresh the deck selector and comparison table with richer specs, wheelbase/weight details, and clearer highlighting
- tidy the overview and BOM styling, ensuring consistent currency display and updated v0.2 branding

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692923b94874832ea20e01626fd65c52)