### PR TITLE
Deduplicate getPriceInfo helper

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,16 +55,6 @@ function getPriceInfo(part?: BuildPart): PriceInfo {
   return { value: offer?.priceUsd, currency: offer ? "USD" : undefined };
 }
 
-function getPriceInfo(part?: BuildPart): PriceInfo {
-  if (!part) return {};
-  if (part.category === "deck") {
-    return { value: part.priceValue, currency: part.priceCurrency };
-  }
-
-  const offer = getPrimaryOffer(part);
-  return { value: offer?.priceUsd, currency: offer ? "USD" : undefined };
-}
-
 function formatNameWithPrice(part?: BuildPart) {
   if (!part) return "Not selected";
   const price = formatPriceDisplay(part);


### PR DESCRIPTION
## Summary
- remove duplicate getPriceInfo helper definition that caused build failure

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292801ab24832eb560f3c0755a4af7)