### PR TITLE
Fix PartCard type guard for optional offers

### DIFF
--- a/app/components/PartCard.tsx
+++ b/app/components/PartCard.tsx
@@ -14,7 +14,7 @@ export function PartCard<T extends BuildPart>({ part, isSelected, onSelect, spec
   const { value, currency } = getPriceInfo(part);
   const priceLabel = formatPrice(value, currency) ?? "See vendor";
 
-  const primaryOffer = part.offers?.[0];
+  const primaryOffer = "offers" in part ? part.offers?.[0] : undefined;
   const productUrl = "productUrl" in part && part.productUrl ? part.productUrl : primaryOffer?.productUrl;
   const vendorName = "vendorName" in part && part.vendorName ? part.vendorName : primaryOffer?.vendorName;
 


### PR DESCRIPTION
## Summary
- guard access to BuildPart offers to accommodate deck entries without offers
- ensure build succeeds after installing missing dependencies

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2f43be6c832e8aa75409101ce55e)